### PR TITLE
Terminate ssm tunnel on exit

### DIFF
--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -122,7 +122,7 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.Result.Set(ctx, &data)...)
 	resp.Private.SetKey(ctx, "tunnel_pid", []byte(strconv.Itoa(forkResult.Command.Process.Pid)))
-	resp.Private.SetKey(ctx, "session_id", []byte(sessionIDBytes))
+	resp.Private.SetKey(ctx, "session_id", sessionIDBytes)
 	resp.Private.SetKey(ctx, "ssm_region", []byte(data.SSMRegion.ValueString()))
 }
 
@@ -165,7 +165,7 @@ func (d *SSMEphemeral) Close(ctx context.Context, req ephemeral.CloseRequest, re
 	ssmClient := aws_ssm.NewFromConfig(awsCfg)
 
 	_, err = ssmClient.TerminateSession(ctx, &aws_ssm.TerminateSessionInput{
-		SessionId: aws.String(string(sessionID)),
+		SessionId: aws.String(sessionID),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to terminate SSM session", fmt.Sprintf("Error: %s", err))

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -137,22 +137,19 @@ func (d *SSMEphemeral) Close(ctx context.Context, req ephemeral.CloseRequest, re
 
 	sessionID, _ := req.Private.GetKey(ctx, "session_id")
 	ssmRegion, _ := req.Private.GetKey(ctx, "ssm_region")
-	if len(sessionID) > 0 {
-		awsCfg, err := config.LoadDefaultConfig(ctx)
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to load AWS config", fmt.Sprintf("Error: %s", err))
-			return
-		}
-		awsCfg.Region = string(ssmRegion)
+	awsCfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(string(ssmRegion)))
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to load AWS config", fmt.Sprintf("Error: %s", err))
+		return
+	}
 
-		ssmClient := aws_ssm.NewFromConfig(awsCfg)
+	ssmClient := aws_ssm.NewFromConfig(awsCfg)
 
-		_, err = ssmClient.TerminateSession(ctx, &aws_ssm.TerminateSessionInput{
-			SessionId: aws.String(string(sessionID)),
-		})
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to terminate SSM session", fmt.Sprintf("Error: %s", err))
-			return
-		}
+	_, err = ssmClient.TerminateSession(ctx, &aws_ssm.TerminateSessionInput{
+		SessionId: aws.String(string(sessionID)),
+	})
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to terminate SSM session", fmt.Sprintf("Error: %s", err))
+		return
 	}
 }

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -17,6 +17,11 @@ import (
 	ps "github.com/shirou/gopsutil/v4/process"
 )
 
+type ForkRemoteResult struct {
+	Command *exec.Cmd
+	Session SessionParams
+}
+
 func GetEndpoint(ctx context.Context, region string) (string, error) {
 	resolver := ssm.NewDefaultEndpointResolverV2()
 	endpoint, err := resolver.ResolveEndpoint(ctx, ssm.EndpointParameters{
@@ -58,7 +63,7 @@ func WatchProcess(pid string) (err error) {
 	return nil
 }
 
-func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) {
+func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*ForkRemoteResult, error) {
 	// First we start a session using AWS SDK
 	// see https://github.com/aws/aws-cli/blob/master/awscli/customizations/sessionmanager.py#L104
 	sessionParams, err := StartTunnelSession(ctx, cfg)
@@ -97,7 +102,10 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 		return nil, err
 	}
 
-	return cmd, nil
+	return &ForkRemoteResult{
+		Command: cmd,
+		Session: sessionParams,
+	}, nil
 }
 
 func StartRemoteTunnel(ctx context.Context, cfg TunnelConfig, parentPid string) (err error) {


### PR DESCRIPTION
Closes https://github.com/dfns/terraform-provider-tunnel/issues/4
- This will allow sharing the SSM session ID so that when `Close()` is called we can call `TerminateSession` in AWS SSM API
- I have tested this on my fork of this repo and can confirm that the tunnel terminates successfully