### PR TITLE
fix: terminate ssm session on interrupt signal

### DIFF
--- a/internal/libs/watch.go
+++ b/internal/libs/watch.go
@@ -11,12 +11,8 @@ import (
 	ps "github.com/shirou/gopsutil/v4/process"
 )
 
-func WatchProcess(pid string) (err error) {
-	pidInt, err := strconv.Atoi(pid)
-	if err != nil {
-		return fmt.Errorf("invalid PID: %v", err)
-	}
-	parent, err := ps.NewProcess(int32(pidInt))
+func WatchProcess(pid int) (err error) {
+	parent, err := ps.NewProcess(int32(pid))
 	if err != nil {
 		return err
 	}

--- a/internal/provider/ephemeral_ssh.go
+++ b/internal/provider/ephemeral_ssh.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ps "github.com/shirou/gopsutil/v4/process"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -139,13 +138,7 @@ func (d *SSHEphemeral) Close(ctx context.Context, req ephemeral.CloseRequest, re
 		return
 	}
 
-	tunnel, err := ps.NewProcess(int32(tunnelPID))
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find tunnel process", fmt.Sprintf("Error: %s", err))
-		return
-	}
-
-	if err := tunnel.Terminate(); err != nil {
+	if err := libs.Interrupt(tunnelPID); err != nil {
 		resp.Diagnostics.AddError("Failed to terminate tunnel process", fmt.Sprintf("Error: %s", err))
 		return
 	}

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	ps "github.com/shirou/gopsutil/v4/process"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -120,13 +119,7 @@ func (d *SSMEphemeral) Close(ctx context.Context, req ephemeral.CloseRequest, re
 		return
 	}
 
-	tunnel, err := ps.NewProcess(int32(tunnelPID))
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find tunnel process", fmt.Sprintf("Error: %s", err))
-		return
-	}
-
-	if err := tunnel.Terminate(); err != nil {
+	if err := libs.Interrupt(tunnelPID); err != nil {
 		resp.Diagnostics.AddError("Failed to terminate tunnel process", fmt.Sprintf("Error: %s", err))
 		return
 	}

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -70,7 +70,7 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	return cmd, nil
 }
 
-func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid string) (err error) {
+func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
 	var cfg TunnelConfig
 	if err := json.Unmarshal([]byte(cfgJson), &cfg); err != nil {
 		return err

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -106,6 +107,15 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid string) (e
 		}
 		_ = conn.Close()
 	})
+
+	// Handle interrupt signal
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+		log.Println("stopping tunnel: received interrupt signal")
+		sshTun.Stop()
+	}()
 
 	if err = sshTun.Start(ctx); err != nil {
 		log.Printf("tunnel error: %v", err)

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -84,7 +84,7 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	return cmd, nil
 }
 
-func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid string) (err error) {
+func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
 	var cfg TunnelConfig
 	if err := json.Unmarshal([]byte(cfgJson), &cfg); err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/provider"
@@ -49,11 +51,19 @@ func StartTunnel(tun string) error {
 		return err
 	}
 
+	if len(os.Args) < 2 {
+		return errors.New("missing parent PID")
+	}
+	parentPid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		return fmt.Errorf("invalid parent PID: %v", err)
+	}
+
 	switch tun {
 	case ssh.TunnelType:
-		return ssh.StartRemoteTunnel(context.Background(), cfgJson, os.Args[1])
+		return ssh.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
 	case ssm.TunnelType:
-		return ssm.StartRemoteTunnel(context.Background(), cfgJson, os.Args[1])
+		return ssm.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
 	default:
 		return errors.New("unknown tunnel type")
 	}


### PR DESCRIPTION
Properly terminating the AWS SSM sessions by sending a `SIGINT` signal to the forked process

Closes #4 