### PR TITLE
feat: add ssh key and password parameters

### DIFF
--- a/docs/data-sources/ssh.md
+++ b/docs/data-sources/ssh.md
@@ -44,6 +44,9 @@ provider "kubernetes" {
 
 ### Optional
 
+- `ssh_key` (String, Sensitive) The path to the private key file or the private key content to use for the SSH connection
+- `ssh_key_passphrase` (String, Sensitive) The passphrase for the private key file
+- `ssh_password` (String, Sensitive) The password to use for the SSH connection
 - `ssh_port` (Number) The port number of the SSH bastion host
 - `ssh_user` (String) The username to use for the SSH connection
 

--- a/docs/ephemeral-resources/ssh.md
+++ b/docs/ephemeral-resources/ssh.md
@@ -44,6 +44,9 @@ provider "kubernetes" {
 
 ### Optional
 
+- `ssh_key` (String, Sensitive) The path to the private key file or the private key content to use for the SSH connection
+- `ssh_key_passphrase` (String, Sensitive) The passphrase for the private key file
+- `ssh_password` (String, Sensitive) The password to use for the SSH connection
 - `ssh_port` (Number) The port number of the SSH bastion host
 - `ssh_user` (String) The username to use for the SSH connection
 


### PR DESCRIPTION

**SSH Authentication**: Added support for SSH key and password authentication to the `tunnel_ssh` resource.
  - `ssh_key` parameter accepting either a file path or inline private key content.
  - `ssh_key_passphrase` parameter for encrypted private keys.
  - `ssh_password` parameter for password-based authentication.