### PR TITLE
ci: goreleaser drop windows arm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,8 @@ builds:
     ignore:
       - goos: darwin
         goarch: "386"
+      - goos: windows
+        goarch: arm
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 archives:
   - formats:


### PR DESCRIPTION
Broken in go 1.24: [golang/go@release-branch.go1.24/src/cmd/dist/build.go#L1826-L1830](https://github.com/golang/go/blob/release-branch.go1.24/src/cmd/dist/build.go#L1826-L1830)

Removed in go 1.26: https://github.com/golang/go/issues/71671