### PR TITLE
ci: renovate enable semantic commits

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -12,6 +12,7 @@ module.exports = {
   postUpdateOptions: ["gomodTidy"],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
+  semanticCommits: "enabled",
   requireConfig: "optional",
   lockFileMaintenance: {
     enabled: false,


### PR DESCRIPTION
Enable semantic commit messages for Renovate bot so dependency update PRs follow conventional commit format (e.g., `chore(deps): update ...`).

- Add `semanticCommits: "enabled"` to `.github/renovate-config.js`