### PR TITLE
ci: migrate Renovate to GitHub App authentication

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -6,7 +6,6 @@ module.exports = {
   branchPrefix: "renovate/",
   dryRun: process.env.RENOVATE_REPOSITORIES ? null : "full",
   enabledManagers: ["gomod", "github-actions"],
-  gitAuthor: "dfns-github-bot <infra@dfns.co>",
   onboarding: false,
   platform: "github",
   postUpdateOptions: ["gomodTidy"],

--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -12,6 +12,8 @@ module.exports = {
   postUpdateOptions: ["gomodTidy"],
   prConcurrentLimit: 0,
   prHourlyLimit: 0,
+  minimumReleaseAge: "7 days",
+  internalChecksFilter: "strict",
   semanticCommits: "enabled",
   requireConfig: "optional",
   lockFileMaintenance: {

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,7 +8,17 @@ on:
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    environment:
+      name: renovate
+      deployment: false
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ vars.RENOVATE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RENOVATE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -16,8 +26,7 @@ jobs:
         uses: renovatebot/github-action@eb932558ad942cccfd8211cf535f17ff183a9f74 # v46.1.9
         with:
           configurationFile: .github/renovate-config.js
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
         env:
           LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.RENOVATE_GIT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary
- Replace the static `RENOVATE_TOKEN` PAT and `RENOVATE_GIT_PRIVATE_KEY` SSH deploy key with a short-lived token generated at runtime via `actions/create-github-app-token`, matching the pattern used in `dfnsco/infrastructure`, `dfns/signers-infra`, and `dfns/glide`.
- Scope the job to a `renovate` GitHub Environment so the app credentials live there rather than as repo-wide secrets.
- Add `minimumReleaseAge: "7 days"` + `internalChecksFilter: "strict"` to the Renovate config so dependency updates wait a week before being proposed (pattern copied from `infrastructure` and `signers-infra`).

## Required repo configuration
Before this runs green, on the `dfns/terraform-provider-tunnel` repo:
- Create a GitHub Environment named `renovate`
- In that environment, set:
  - Variable: `RENOVATE_APP_CLIENT_ID`
  - Secret: `RENOVATE_APP_PRIVATE_KEY`

Once confirmed working, the old `RENOVATE_TOKEN` and `RENOVATE_GIT_PRIVATE_KEY` secrets can be removed.

## Test plan
- [ ] Create the `renovate` environment and populate its variable/secret
- [ ] Trigger the workflow via `workflow_dispatch` and confirm Renovate runs, opens/updates PRs, and commits are authored by the GitHub App bot
- [ ] Confirm newly released deps aren't proposed until 7 days after release
- [ ] Remove the stale `RENOVATE_TOKEN` / `RENOVATE_GIT_PRIVATE_KEY` secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)