### PR TITLE
fix: ssh tunnel ready-file collision

### DIFF
--- a/internal/libs/watch.go
+++ b/internal/libs/watch.go
@@ -106,7 +106,6 @@ func WaitForReadyFile(pid int, path string) error {
 			return fmt.Errorf("process exited unexpectedly")
 		}
 		if _, err := os.Stat(path); err == nil {
-			os.Remove(path)
 			return nil
 		}
 		time.Sleep(500 * time.Millisecond)

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -48,8 +48,10 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	// Prepare the command
 	cmd := exec.Command(os.Args[0], strconv.Itoa(os.Getppid()))
 
-	// Create a temp file path for the ready signal (use PID for uniqueness)
-	readyFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-ready-%d", os.Getpid()))
+	// LocalPort is unique per resource, giving each concurrent fork its own ready file.
+	readyFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-ready-%d-%d", os.Getpid(), cfg.LocalPort))
+	os.Remove(readyFilePath)
+	defer os.Remove(readyFilePath)
 
 	// Append ssh tunnel config environment variable to pass parameters to the child process
 	cmd.Env = append(


### PR DESCRIPTION
Fixes #167

Concurrent `tunnel_ssh` ephemeral resources sharing one Terraform process were colliding on a single ready-signal file path keyed by `os.Getpid()`, so one parent could consume another's signal and time out with `tunnel not ready after 30s` while the tunnel itself had connected fine. Regression introduced in v1.5.8 (#137).

- Include `cfg.LocalPort` in the ready-file path so each concurrent fork gets its own file.
- Move file cleanup to `defer os.Remove` in `ForkRemoteTunnel`; drop the redundant `os.Remove` in `WaitForReadyFile` so the wait function only observes state.
