### PR TITLE
feat(ssh): support forwarding to remote unix domain sockets

### DIFF
--- a/docs/data-sources/ssh.md
+++ b/docs/data-sources/ssh.md
@@ -39,8 +39,6 @@ provider "kubernetes" {
 ### Required
 
 - `ssh_host` (String) The DNS name or IP address of the SSH bastion host
-- `target_host` (String) The DNS name or IP address of the remote host
-- `target_port` (Number) The port number of the remote host
 
 ### Optional
 
@@ -49,6 +47,9 @@ provider "kubernetes" {
 - `ssh_password` (String, Sensitive) The password to use for the SSH connection
 - `ssh_port` (Number) The port number of the SSH bastion host
 - `ssh_user` (String) The username to use for the SSH connection
+- `target_host` (String) The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.
+- `target_port` (Number) The TCP port of the remote host. Mutually exclusive with `target_socket`.
+- `target_socket` (String) Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/ssh.md
+++ b/docs/ephemeral-resources/ssh.md
@@ -39,8 +39,6 @@ provider "kubernetes" {
 ### Required
 
 - `ssh_host` (String) The DNS name or IP address of the SSH bastion host
-- `target_host` (String) The DNS name or IP address of the remote host
-- `target_port` (Number) The port number of the remote host
 
 ### Optional
 
@@ -49,6 +47,9 @@ provider "kubernetes" {
 - `ssh_password` (String, Sensitive) The password to use for the SSH connection
 - `ssh_port` (Number) The port number of the SSH bastion host
 - `ssh_user` (String) The username to use for the SSH connection
+- `target_host` (String) The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.
+- `target_port` (Number) The TCP port of the remote host. Mutually exclusive with `target_socket`.
+- `target_socket` (String) Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.
 
 ### Read-Only
 

--- a/internal/provider/data_source_ssh.go
+++ b/internal/provider/data_source_ssh.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/user"
 
@@ -11,6 +12,20 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func validateSSHTarget(targetHost, targetSocket types.String, targetPort types.Int64) error {
+	hasPort := !targetPort.IsNull()
+	hasSocket := !targetSocket.IsNull() && targetSocket.ValueString() != ""
+	switch {
+	case hasPort && hasSocket:
+		return errors.New("`target_port` and `target_socket` are mutually exclusive")
+	case !hasPort && !hasSocket:
+		return errors.New("one of `target_port` or `target_socket` must be set")
+	case hasPort && (targetHost.IsNull() || targetHost.ValueString() == ""):
+		return errors.New("`target_host` is required when `target_port` is set")
+	}
+	return nil
+}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &SSHDataSource{}
@@ -34,6 +49,7 @@ type SSHDataSourceModel struct {
 	SSHUser          types.String `tfsdk:"ssh_user"`
 	TargetHost       types.String `tfsdk:"target_host"`
 	TargetPort       types.Int64  `tfsdk:"target_port"`
+	TargetSocket     types.String `tfsdk:"target_socket"`
 }
 
 func (d *SSHDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -45,14 +61,17 @@ func (d *SSHDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 		MarkdownDescription: "Create a local SSH tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
-				MarkdownDescription: "The port number of the remote host",
-				Required:            true,
+				MarkdownDescription: "The TCP port of the remote host. Mutually exclusive with `target_socket`.",
+				Optional:            true,
+			},
+			"target_socket": schema.StringAttribute{
+				MarkdownDescription: "Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.",
+				Optional:            true,
 			},
 			"ssh_host": schema.StringAttribute{
 				MarkdownDescription: "The DNS name or IP address of the SSH bastion host",
@@ -106,6 +125,11 @@ func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
+	if err := validateSSHTarget(data.TargetHost, data.TargetSocket, data.TargetPort); err != nil {
+		resp.Diagnostics.AddError("Invalid target configuration", err.Error())
+		return
+	}
+
 	// Get a free port for the local tunnel
 	localPort, err := libs.GetFreePort()
 	if err != nil {
@@ -138,6 +162,7 @@ func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		SSHUser:          data.SSHUser.ValueString(),
 		TargetHost:       data.TargetHost.ValueString(),
 		TargetPort:       int(data.TargetPort.ValueInt64()),
+		TargetSocket:     data.TargetSocket.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to fork tunnel process", fmt.Sprintf("Error: %s", err))

--- a/internal/provider/ephemeral_ssh.go
+++ b/internal/provider/ephemeral_ssh.go
@@ -35,6 +35,7 @@ type SSHEphemeralModel struct {
 	SSHUser          types.String `tfsdk:"ssh_user"`
 	TargetHost       types.String `tfsdk:"target_host"`
 	TargetPort       types.Int64  `tfsdk:"target_port"`
+	TargetSocket     types.String `tfsdk:"target_socket"`
 }
 
 func (d *SSHEphemeral) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
@@ -46,14 +47,17 @@ func (d *SSHEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 		MarkdownDescription: "Create a local SSH tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
-				MarkdownDescription: "The port number of the remote host",
-				Required:            true,
+				MarkdownDescription: "The TCP port of the remote host. Mutually exclusive with `target_socket`.",
+				Optional:            true,
+			},
+			"target_socket": schema.StringAttribute{
+				MarkdownDescription: "Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.",
+				Optional:            true,
 			},
 			"ssh_host": schema.StringAttribute{
 				MarkdownDescription: "The DNS name or IP address of the SSH bastion host",
@@ -107,6 +111,11 @@ func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
+	if err := validateSSHTarget(data.TargetHost, data.TargetSocket, data.TargetPort); err != nil {
+		resp.Diagnostics.AddError("Invalid target configuration", err.Error())
+		return
+	}
+
 	// Get a free port for the local tunnel
 	localPort, err := libs.GetFreePort()
 	if err != nil {
@@ -139,6 +148,7 @@ func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		SSHUser:          data.SSHUser.ValueString(),
 		TargetHost:       data.TargetHost.ValueString(),
 		TargetPort:       int(data.TargetPort.ValueInt64()),
+		TargetSocket:     data.TargetSocket.ValueString(),
 	})
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to fork tunnel process", fmt.Sprintf("Error: %s", err))

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -30,6 +30,7 @@ type TunnelConfig struct {
 	SSHUser          string
 	TargetHost       string
 	TargetPort       int
+	TargetSocket     string
 }
 
 func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) {
@@ -39,7 +40,11 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	}
 
 	// Open a log file for the tunnel
-	tunnelLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-%s-%d.log", cfg.SSHHost, cfg.TargetPort))
+	target := strconv.Itoa(cfg.TargetPort)
+	if cfg.TargetSocket != "" {
+		target = strings.ReplaceAll(cfg.TargetSocket, string(os.PathSeparator), "_")
+	}
+	tunnelLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-%s-%s.log", cfg.SSHHost, target))
 	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
@@ -87,12 +92,20 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 		return err
 	}
 
-	log.Printf("starting tunnel: localhost:%d - %s:%d - %s:%d", cfg.LocalPort, cfg.SSHHost, cfg.SSHPort, cfg.TargetHost, cfg.TargetPort)
+	target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
+	if cfg.TargetSocket != "" {
+		target = cfg.TargetSocket
+	}
+	log.Printf("starting tunnel: localhost:%d - %s:%d - %s", cfg.LocalPort, cfg.SSHHost, cfg.SSHPort, target)
 
 	sshTun := sshtun.New(cfg.LocalPort, cfg.SSHHost, cfg.TargetPort)
 	sshTun.SetPort(cfg.SSHPort)
 	sshTun.SetUser(cfg.SSHUser)
-	sshTun.SetRemoteHost(cfg.TargetHost)
+	if cfg.TargetSocket != "" {
+		sshTun.SetRemoteEndpoint(sshtun.NewUnixEndpoint(cfg.TargetSocket))
+	} else {
+		sshTun.SetRemoteHost(cfg.TargetHost)
+	}
 
 	if cfg.SSHPassword != "" {
 		sshTun.SetPassword(cfg.SSHPassword)


### PR DESCRIPTION
Adds an optional `target_socket` attribute on `tunnel_ssh` (data source and ephemeral resource) to forward a local TCP port to a unix domain socket on the SSH bastion. This unblocks Terraform providers that need to reach socket-only daemons on the bastion (e.g. `/var/run/docker.sock`, peer-auth Postgres).

- Add `TargetSocket` to `ssh.TunnelConfig`; when set, the runner uses `sshtun.SetRemoteEndpoint(NewUnixEndpoint(...))` instead of `SetRemoteHost`
- Add `target_socket` (Optional, String) to the `tunnel_ssh` data source and ephemeral resource schemas

Closes #158
