### PR TITLE
fix: failed to fork tunnel process on Windows

### DIFF
--- a/internal/libs/watch.go
+++ b/internal/libs/watch.go
@@ -13,10 +13,6 @@ import (
 )
 
 func WatchProcess(pid int) (err error) {
-	parent, err := ps.NewProcess(int32(pid))
-	if err != nil {
-		return err
-	}
 	child, err := ps.NewProcess(int32(os.Getpid()))
 	if err != nil {
 		return err
@@ -24,7 +20,7 @@ func WatchProcess(pid int) (err error) {
 	// pool for parent process liveliness every 2 seconds
 	go func() {
 		for {
-			_, err := parent.Status()
+			err := CheckProcessExists(pid)
 			if err != nil {
 				log.Printf("parent process exited: %v\n", err)
 				if runtime.GOOS == "windows" {
@@ -44,14 +40,28 @@ func WatchProcess(pid int) (err error) {
 }
 
 func CheckProcessExists(pid int) error {
+  exists, err := ps.PidExists(int32(pid))
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return fmt.Errorf("process died")
+	}
+
+	if runtime.GOOS == "windows" {
+		return nil
+	}
+
 	cmd, err := ps.NewProcess(int32(pid))
 	if err != nil {
 		return err
 	}
+
 	stats, err := cmd.Status()
 	if err != nil {
 		return err
 	}
+
 	if stats[0] == "zombie" {
 		return fmt.Errorf("process died")
 	}


### PR DESCRIPTION
This PR fixes error `Failed to fork tunnel process` when using `tunnel_ssm` data source on Windows. The changes involve using `CheckProcessExists` in `WatchProcess` to check pid as an alternative to `parent.Status()` since that method will throw `ErrNotImplementedError`. 
```
│ Error: Failed to fork tunnel process
│
│   with data.tunnel_ssm.aws_db,
│   on aws_db_user.tf line 1, in data "tunnel_ssm" "aws_db":
│    1: data "tunnel_ssm" "aws_db" {
│
│ Error: process exited unexpectedly. check C:\Users\user\AppData\Local\Temp\ssm-tunnel-i-0c30f4bd2cb815da2-5432.log for more
│ information
```