### PR TITLE
test: add unit integration and e2e test suites

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,25 @@
 # Terraform Provider testing workflow.
 name: Tests
 
-# This GitHub action runs your tests for each pull request and push.
-# Optionally, you can turn it on using a schedule for regular testing.
+# Runs build/lint, doc generation, unit, integration and end-to-end tests for
+# each pull request and for pushes to main.
 on:
   pull_request:
     paths-ignore:
       - "README.md"
   push:
+    branches:
+      - main
     paths-ignore:
       - "README.md"
 
 # Testing only needs permissions to read the repository contents.
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Ensure project builds before running testing matrix
@@ -35,6 +41,7 @@ jobs:
           version: latest
 
   generate:
+    name: Generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -52,18 +59,62 @@ jobs:
           git diff --compact-summary --exit-code || \
             (echo; echo "Unexpected difference in directories after code generation. Run 'make generate' command and commit."; exit 1)
 
-  # Run acceptance tests in a matrix with Terraform CLI versions
-  test:
-    name: Terraform Provider Acceptance Tests
+  # Fast, dependency-free unit tests across all packages.
+  unit:
+    name: Unit tests
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go mod download
+      - run: go test -v -cover ./...
+
+  # Integration tests for the fork/process-watch primitives. Run on all three
+  # major OSes since the process-signal path (SIGINT vs Terminate) is OS-specific.
+  integration:
+    name: Integration tests (${{ matrix.os }})
+    needs: build
     strategy:
       fail-fast: false
       matrix:
-        # list whatever Terraform versions here you would like to support
-        terraform:
-          - "1.5.*"
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - run: go mod download
+      - run: go test -v -tags integration -timeout 120s ./test/integration/
+
+  # End-to-end: build the real provider and drive it through `terraform apply`
+  # against live fixtures, so OS-specific regressions in the fork/process-watch
+  # path cannot merge.
+  #
+  # tunnel_ssh against an in-process SSH bastion + HTTP target. Runs on all three
+  # major OSes since the fork/process-watch path is OS-specific.
+  ssh-e2e:
+    name: SSH tunnel (${{ matrix.os }})
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -72,10 +123,32 @@ jobs:
           cache: true
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: ${{ matrix.terraform }}
+          terraform_version: "1.10.5"
           terraform_wrapper: false
-      - run: go mod download
-      - env:
-          TF_ACC: "1"
-        run: go test -v -cover ./internal/provider/
-        timeout-minutes: 10
+      - run: go test -v -tags e2e -run TestSSHTunnelE2E -timeout 10m ./test/e2e/
+
+  # tunnel_kubernetes against a kind cluster, forwarding to the built-in CoreDNS
+  # metrics endpoint. Linux-only: kind needs a Linux Docker host.
+  k8s-e2e:
+    name: Kubernetes tunnel
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache: true
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.10.5"
+          terraform_wrapper: false
+      - uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          cluster_name: tunnel-e2e
+      - name: Wait for CoreDNS
+        run: kubectl wait --for=condition=Available deploy/coredns -n kube-system --timeout=120s
+      - run: go test -v -tags e2e -run TestKubernetesTunnelE2E -timeout 10m ./test/e2e/
+        env:
+          E2E_KUBE_CONTEXT: kind-tunnel-e2e

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,13 @@ fmt:
 test:
 	go test -v -cover -timeout=120s -parallel=10 ./...
 
+test-integration:
+	go test -v -tags integration -timeout=120s ./test/integration/
+
+test-e2e:
+	go test -v -tags e2e -timeout=10m ./test/e2e/
+
 testacc:
 	TF_ACC=1 go test -v -cover -timeout 120m ./...
 
-.PHONY: fmt lint test testacc build install generate
+.PHONY: fmt lint test test-integration test-e2e testacc build install generate

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/rgzr/sshtun v1.2.3
 	github.com/shirou/gopsutil/v4 v4.26.4
+	golang.org/x/crypto v0.47.0
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 )
@@ -83,7 +84,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect

--- a/internal/kubernetes/tunnel.go
+++ b/internal/kubernetes/tunnel.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
@@ -63,7 +62,7 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	}
 
 	// Open a log file for the tunnel
-	tunnelLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("k8s-tunnel-%s-%s-%d.log", cfg.Namespace, cfg.ServiceName, cfg.TargetPort))
+	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("k8s-tunnel-%s-%s-%d.log", cfg.Namespace, cfg.ServiceName, cfg.TargetPort))
 	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err

--- a/internal/libs/const.go
+++ b/internal/libs/const.go
@@ -1,7 +1,8 @@
 package libs
 
 const (
-	TunnelTypeEnv  = "DFNS_TERRAFORM_TUNNEL_TYPE"
-	TunnelConfEnv  = "DFNS_TERRAFORM_TUNNEL_CONF"
-	TunnelReadyEnv = "DFNS_TERRAFORM_TUNNEL_READY"
+	TunnelTypeEnv   = "DFNS_TERRAFORM_TUNNEL_TYPE"
+	TunnelConfEnv   = "DFNS_TERRAFORM_TUNNEL_CONF"
+	TunnelReadyEnv  = "DFNS_TERRAFORM_TUNNEL_READY"
+	TunnelLogDirEnv = "DFNS_TERRAFORM_TUNNEL_LOG_DIR"
 )

--- a/internal/libs/log.go
+++ b/internal/libs/log.go
@@ -1,0 +1,14 @@
+package libs
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func TunnelLogPath(name string) string {
+	dir := os.Getenv(TunnelLogDirEnv)
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	return filepath.Join(dir, name)
+}

--- a/internal/libs/watch.go
+++ b/internal/libs/watch.go
@@ -82,7 +82,7 @@ func WaitForPort(pid int, host string, port string) error {
 	addr := net.JoinHostPort(host, port)
 	for time.Now().Before(deadline) {
 		if err := CheckProcessExists(pid); err != nil {
-			return fmt.Errorf("process exited unexpectedly")
+			return fmt.Errorf("process exited unexpectedly: %w", err)
 		}
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
@@ -103,7 +103,7 @@ func WaitForReadyFile(pid int, path string) error {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		if err := CheckProcessExists(pid); err != nil {
-			return fmt.Errorf("process exited unexpectedly")
+			return fmt.Errorf("process exited unexpectedly: %w", err)
 		}
 		if _, err := os.Stat(path); err == nil {
 			return nil

--- a/internal/provider/data_source_ssh_test.go
+++ b/internal/provider/data_source_ssh_test.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestValidateSSHTarget exercises every branch of the target validation: the
+// two valid shapes (host+port, socket) and the three rejected ones (both set,
+// neither set, port without a host).
+func TestValidateSSHTarget(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetHost types.String
+		socket     types.String
+		port       types.Int64
+		wantErr    string
+	}{
+		{
+			name:       "port with host is valid",
+			targetHost: types.StringValue("db.internal"),
+			socket:     types.StringNull(),
+			port:       types.Int64Value(5432),
+		},
+		{
+			name:       "socket only is valid",
+			targetHost: types.StringNull(),
+			socket:     types.StringValue("/var/run/app.sock"),
+			port:       types.Int64Null(),
+		},
+		{
+			name:       "port and socket are mutually exclusive",
+			targetHost: types.StringValue("db.internal"),
+			socket:     types.StringValue("/var/run/app.sock"),
+			port:       types.Int64Value(5432),
+			wantErr:    "mutually exclusive",
+		},
+		{
+			name:       "neither port nor socket set",
+			targetHost: types.StringValue("db.internal"),
+			socket:     types.StringNull(),
+			port:       types.Int64Null(),
+			wantErr:    "must be set",
+		},
+		{
+			name:       "port without host",
+			targetHost: types.StringNull(),
+			socket:     types.StringNull(),
+			port:       types.Int64Value(5432),
+			wantErr:    "`target_host` is required",
+		},
+		{
+			name:       "port with empty host",
+			targetHost: types.StringValue(""),
+			socket:     types.StringNull(),
+			port:       types.Int64Value(5432),
+			wantErr:    "`target_host` is required",
+		},
+		{
+			name:       "empty socket counts as unset",
+			targetHost: types.StringNull(),
+			socket:     types.StringValue(""),
+			port:       types.Int64Null(),
+			wantErr:    "must be set",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSSHTarget(tt.targetHost, tt.socket, tt.port)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/runner/tunnel.go
+++ b/internal/runner/tunnel.go
@@ -1,0 +1,43 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	k8s "github.com/dfns/terraform-provider-tunnel/internal/kubernetes"
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssm"
+)
+
+func StartTunnel(tun string) error {
+	cfgJson := os.Getenv(libs.TunnelConfEnv)
+	if cfgJson == "" {
+		return errors.New("missing tunnel configuration")
+	}
+	if err := os.Unsetenv(libs.TunnelConfEnv); err != nil {
+		return err
+	}
+
+	if len(os.Args) < 2 {
+		return errors.New("missing parent PID")
+	}
+	parentPid, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		return fmt.Errorf("invalid parent PID: %w", err)
+	}
+
+	switch tun {
+	case ssh.TunnelType:
+		return ssh.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
+	case ssm.TunnelType:
+		return ssm.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
+	case k8s.TunnelType:
+		return k8s.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
+	default:
+		return errors.New("unknown tunnel type")
+	}
+}

--- a/internal/runner/tunnel_test.go
+++ b/internal/runner/tunnel_test.go
@@ -1,0 +1,84 @@
+package runner
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+)
+
+// TestStartTunnelErrors guards the binary's entry-point dispatch: a tunnel is
+// only started once the config env, the parent PID argument and the tunnel type
+// are all present and valid. The successful fork path is covered in the
+// integration and e2e suites.
+func TestStartTunnelErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		tun     string
+		conf    string
+		setConf bool
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "missing tunnel configuration",
+			tun:     "ssh",
+			setConf: false,
+			args:    []string{"terraform-provider-tunnel", "1"},
+			wantErr: "missing tunnel configuration",
+		},
+		{
+			name:    "missing parent PID",
+			tun:     "ssh",
+			conf:    "{}",
+			setConf: true,
+			args:    []string{"terraform-provider-tunnel"},
+			wantErr: "missing parent PID",
+		},
+		{
+			name:    "invalid parent PID",
+			tun:     "ssh",
+			conf:    "{}",
+			setConf: true,
+			args:    []string{"terraform-provider-tunnel", "not-a-number"},
+			wantErr: "invalid parent PID",
+		},
+		{
+			name:    "unknown tunnel type",
+			tun:     "bogus",
+			conf:    "{}",
+			setConf: true,
+			args:    []string{"terraform-provider-tunnel", "1"},
+			wantErr: "unknown tunnel type",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setConf {
+				t.Setenv(libs.TunnelConfEnv, tt.conf)
+			} else {
+				prev, had := os.LookupEnv(libs.TunnelConfEnv)
+				_ = os.Unsetenv(libs.TunnelConfEnv)
+				t.Cleanup(func() {
+					if had {
+						_ = os.Setenv(libs.TunnelConfEnv, prev)
+					}
+				})
+			}
+
+			origArgs := os.Args
+			os.Args = tt.args
+			t.Cleanup(func() { os.Args = origArgs })
+
+			err := StartTunnel(tt.tun)
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -44,7 +44,7 @@ func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) 
 	if cfg.TargetSocket != "" {
 		target = strings.ReplaceAll(cfg.TargetSocket, string(os.PathSeparator), "_")
 	}
-	tunnelLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-%s-%s.log", cfg.SSHHost, target))
+	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssh-tunnel-%s-%s.log", cfg.SSHHost, target))
 	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err

--- a/internal/sshtest/doc.go
+++ b/internal/sshtest/doc.go
@@ -1,0 +1,9 @@
+// Package sshtest provides an in-process SSH bastion for tunnel tests. The
+// server authenticates a generated key and services "direct-tcpip" channels
+// (the server side of `ssh -L`), so a tunnel can forward through it to an
+// arbitrary local target without any external SSH daemon.
+//
+// The implementation lives in a build-tagged file (e2e || integration) so it is
+// only compiled into test binaries that need it; this untagged file keeps the
+// package buildable for `go build ./...` and linters when no tag is set.
+package sshtest

--- a/internal/sshtest/server.go
+++ b/internal/sshtest/server.go
@@ -1,0 +1,145 @@
+//go:build e2e || integration
+
+package sshtest
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// User is the username the in-process server accepts. Authentication is by key,
+// so the username is only there to satisfy the SSH handshake.
+const User = "tunneltest"
+
+// newEd25519Signer generates a fresh ed25519 key pair and returns the raw
+// private key (for PEM marshaling) alongside its SSH signer.
+func newEd25519Signer(t testing.TB) (ed25519.PrivateKey, ssh.Signer) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("generating ed25519 key: %v", err)
+	}
+	signer, err := ssh.NewSignerFromKey(priv)
+	if err != nil {
+		t.Fatalf("creating signer: %v", err)
+	}
+	return priv, signer
+}
+
+// GenerateClientKey returns an OpenSSH-PEM-encoded private key (suitable for the
+// provider's ssh_key) and the matching public key to authorize on the server.
+func GenerateClientKey(t testing.TB) (string, ssh.PublicKey) {
+	t.Helper()
+	priv, signer := newEd25519Signer(t)
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		t.Fatalf("marshaling key: %v", err)
+	}
+	return string(pem.EncodeToMemory(block)), signer.PublicKey()
+}
+
+// StartServer starts a minimal SSH server on a random localhost port that
+// authenticates the given key and handles "direct-tcpip" (ssh -L) channels so a
+// local forward works. It returns the listening port and tears the server down
+// on test cleanup.
+func StartServer(t testing.TB, authorizedKey ssh.PublicKey) int {
+	t.Helper()
+
+	_, hostSigner := newEd25519Signer(t)
+	config := &ssh.ServerConfig{
+		PublicKeyCallback: func(_ ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), authorizedKey.Marshal()) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unauthorized public key")
+		},
+	}
+	config.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listening: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return // listener closed during cleanup
+			}
+			go handleSSHConn(conn, config)
+		}
+	}()
+
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address is not TCP: %T", ln.Addr())
+	}
+	return addr.Port
+}
+
+func handleSSHConn(c net.Conn, config *ssh.ServerConfig) {
+	sshConn, chans, reqs, err := ssh.NewServerConn(c, config)
+	if err != nil {
+		return // handshake/auth failure
+	}
+	defer sshConn.Close()
+
+	go ssh.DiscardRequests(reqs)
+
+	for nc := range chans {
+		if nc.ChannelType() != "direct-tcpip" {
+			_ = nc.Reject(ssh.UnknownChannelType, "only direct-tcpip is supported")
+			continue
+		}
+		go handleDirectTCPIP(nc)
+	}
+}
+
+// handleDirectTCPIP dials the requested destination and pipes bytes between the
+// SSH channel and that connection (the server side of `ssh -L`).
+func handleDirectTCPIP(nc ssh.NewChannel) {
+	var payload struct {
+		DestAddr string
+		DestPort uint32
+		SrcAddr  string
+		SrcPort  uint32
+	}
+	if err := ssh.Unmarshal(nc.ExtraData(), &payload); err != nil {
+		_ = nc.Reject(ssh.ConnectionFailed, "bad direct-tcpip payload")
+		return
+	}
+
+	dest := net.JoinHostPort(payload.DestAddr, strconv.Itoa(int(payload.DestPort)))
+	target, err := net.Dial("tcp", dest)
+	if err != nil {
+		_ = nc.Reject(ssh.ConnectionFailed, err.Error())
+		return
+	}
+
+	ch, chReqs, err := nc.Accept()
+	if err != nil {
+		_ = target.Close()
+		return
+	}
+	go ssh.DiscardRequests(chReqs)
+
+	go func() {
+		_, _ = io.Copy(ch, target)
+		_ = ch.CloseWrite()
+	}()
+	go func() {
+		_, _ = io.Copy(target, ch)
+		_ = target.Close()
+	}()
+}

--- a/internal/ssm/session_test.go
+++ b/internal/ssm/session_test.go
@@ -1,0 +1,79 @@
+package ssm
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+// TestCreateSessionInput verifies the AWS port-forwarding request is assembled
+// from the tunnel config: the document name is fixed and the three parameters
+// map to the configured target port, local port and host.
+func TestCreateSessionInput(t *testing.T) {
+	cfg := TunnelConfig{
+		LocalPort:   "12345",
+		SSMInstance: "i-0abc123",
+		TargetHost:  "db.internal",
+		TargetPort:  "5432",
+	}
+
+	in := CreateSessionInput(cfg)
+
+	if in.Target == nil || *in.Target != cfg.SSMInstance {
+		t.Errorf("Target = %v, want %q", in.Target, cfg.SSMInstance)
+	}
+	if in.DocumentName == nil || *in.DocumentName != "AWS-StartPortForwardingSessionToRemoteHost" {
+		t.Errorf("DocumentName = %v, want AWS-StartPortForwardingSessionToRemoteHost", in.DocumentName)
+	}
+
+	wantParams := map[string]string{
+		"portNumber":      "5432",
+		"localPortNumber": "12345",
+		"host":            "db.internal",
+	}
+	for key, want := range wantParams {
+		got, ok := in.Parameters[key]
+		if !ok {
+			t.Errorf("missing parameter %q", key)
+			continue
+		}
+		if len(got) != 1 || got[0] != want {
+			t.Errorf("parameter %q = %v, want [%q]", key, got, want)
+		}
+	}
+}
+
+// TestGetSDKConfigProfileAndRole checks that the profile and role ARN are read
+// out of the resolved SDK config's shared-config source, and that unrelated
+// sources are ignored rather than panicking the type assertion.
+func TestGetSDKConfigProfileAndRole(t *testing.T) {
+	t.Run("reads from shared config source", func(t *testing.T) {
+		const wantProfile = "myprofile"
+		const wantRole = "arn:aws:iam::123456789012:role/demo"
+
+		cfg := aws.Config{
+			ConfigSources: []interface{}{
+				config.SharedConfig{Profile: wantProfile, RoleARN: wantRole},
+			},
+		}
+
+		if got := GetSDKConfigProfile(cfg); got != wantProfile {
+			t.Errorf("GetSDKConfigProfile = %q, want %q", got, wantProfile)
+		}
+		if got := GetSDKConfigRole(cfg); got != wantRole {
+			t.Errorf("GetSDKConfigRole = %q, want %q", got, wantRole)
+		}
+	})
+
+	t.Run("returns empty when no shared config is present", func(t *testing.T) {
+		cfg := aws.Config{ConfigSources: []interface{}{"not-a-shared-config"}}
+
+		if got := GetSDKConfigProfile(cfg); got != "" {
+			t.Errorf("GetSDKConfigProfile = %q, want empty", got)
+		}
+		if got := GetSDKConfigRole(cfg); got != "" {
+			t.Errorf("GetSDKConfigRole = %q, want empty", got)
+		}
+	})
+}

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -48,7 +47,7 @@ func ForkRemoteTunnel(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) 
 	}
 
 	// Open a log file for the tunnel
-	tunnelLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, cfg.TargetPort))
+	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, cfg.TargetPort))
 	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -5,18 +5,13 @@ package main
 
 import (
 	"context"
-	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"os"
-	"strconv"
 
-	k8s "github.com/dfns/terraform-provider-tunnel/internal/kubernetes"
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/provider"
-	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
-	"github.com/dfns/terraform-provider-tunnel/internal/ssm"
+	"github.com/dfns/terraform-provider-tunnel/internal/runner"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
@@ -43,40 +38,11 @@ func StartServer() error {
 	return providerserver.Serve(context.Background(), provider.New(version), opts)
 }
 
-func StartTunnel(tun string) error {
-	cfgJson := os.Getenv(libs.TunnelConfEnv)
-	if cfgJson == "" {
-		return errors.New("missing tunnel configuration")
-	}
-	if err := os.Unsetenv(libs.TunnelConfEnv); err != nil {
-		return err
-	}
-
-	if len(os.Args) < 2 {
-		return errors.New("missing parent PID")
-	}
-	parentPid, err := strconv.Atoi(os.Args[1])
-	if err != nil {
-		return fmt.Errorf("invalid parent PID: %v", err)
-	}
-
-	switch tun {
-	case ssh.TunnelType:
-		return ssh.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
-	case ssm.TunnelType:
-		return ssm.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
-	case k8s.TunnelType:
-		return k8s.StartRemoteTunnel(context.Background(), cfgJson, parentPid)
-	default:
-		return errors.New("unknown tunnel type")
-	}
-}
-
 func main() {
 	var err error
 
 	if tun := os.Getenv(libs.TunnelTypeEnv); tun != "" {
-		err = StartTunnel(tun)
+		err = runner.StartTunnel(tun)
 	} else {
 		err = StartServer()
 	}

--- a/test/e2e/doc.go
+++ b/test/e2e/doc.go
@@ -1,0 +1,5 @@
+// Package e2e contains end-to-end tests for the tunnel provider.
+//
+// This file is intentionally untagged so the package always has a buildable
+// Go file, keeping `go build ./...` and linters happy when the tag is absent.
+package e2e

--- a/test/e2e/k8s_test.go
+++ b/test/e2e/k8s_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+)
+
+// TestKubernetesTunnelE2E drives the tunnel_kubernetes data source against a
+// real cluster (a kind cluster in CI). It forwards to the built-in CoreDNS
+// service (kube-system/kube-dns) on its Prometheus metrics port and asserts a
+// real HTTP request reaches the pod. Reusing CoreDNS means no workload to
+// deploy. Skips if no kubeconfig is available (e.g. SSH-only runners).
+func TestKubernetesTunnelE2E(t *testing.T) {
+	kubeconfig := resolveKubeconfig(t)
+	kubeContext := os.Getenv("E2E_KUBE_CONTEXT")
+
+	// Auto-assigned local port: the provider picks a free port (the common case).
+	t.Run("auto_port", func(t *testing.T) {
+		runKubernetesTunnelCase(t, kubeconfig, kubeContext, 0)
+	})
+
+	// Explicit local port: the provider must honor a caller-supplied port rather
+	// than allocating one (the local_port != 0 branch in the data source Read).
+	t.Run("explicit_port", func(t *testing.T) {
+		port, err := libs.GetFreePort()
+		if err != nil {
+			t.Fatalf("allocating free port: %v", err)
+		}
+		runKubernetesTunnelCase(t, kubeconfig, kubeContext, port)
+	})
+}
+
+// runKubernetesTunnelCase applies a tunnel_kubernetes config, verifies a real
+// request flows through the tunnel, and checks the forked process self-terminates.
+// requestedPort == 0 lets the provider choose the local port; otherwise the
+// provider must bind exactly requestedPort.
+func runKubernetesTunnelCase(t *testing.T, kubeconfig, kubeContext string, requestedPort int) {
+	t.Helper()
+
+	contextLine := ""
+	if kubeContext != "" {
+		contextLine = fmt.Sprintf("\n    config_context = %q", kubeContext)
+	}
+
+	localPortLine := ""
+	if requestedPort != 0 {
+		localPortLine = fmt.Sprintf("\n  local_port   = %d", requestedPort)
+	}
+
+	moduleDir := t.TempDir()
+
+	config := fmt.Sprintf(`
+terraform {
+  required_providers {
+    tunnel = {
+      source = "dfns/tunnel"
+    }
+  }
+}
+
+data "tunnel_kubernetes" "t" {
+  namespace    = "kube-system"
+  service_name = "kube-dns"
+  target_port  = 9153%s
+  kubernetes = {
+    config_path = %q%s
+  }
+}
+
+resource "terraform_data" "probe" {
+  input = data.tunnel_kubernetes.t.local_port
+  provisioner "local-exec" {
+    command = "curl -fsS -o resp.txt http://${data.tunnel_kubernetes.t.local_host}:${data.tunnel_kubernetes.t.local_port}/metrics"
+  }
+}
+
+output "local_port" {
+  value = data.tunnel_kubernetes.t.local_port
+}
+`, localPortLine, filepath.ToSlash(kubeconfig), contextLine)
+
+	terraformApply(t, moduleDir, config)
+
+	got, err := os.ReadFile(filepath.Join(moduleDir, "resp.txt"))
+	if err != nil {
+		t.Fatalf("reading tunneled response: %v", err)
+	}
+	// CoreDNS exposes Prometheus metrics; the body must contain HELP markers.
+	if !strings.Contains(string(got), "# HELP") {
+		t.Fatalf("k8s tunnel /metrics response missing Prometheus markers; got %d bytes:\n%.300s", len(got), got)
+	}
+
+	localPort, err := strconv.Atoi(terraformOutput(t, moduleDir, "local_port"))
+	if err != nil {
+		t.Fatalf("parsing local_port output: %v", err)
+	}
+	if requestedPort != 0 && localPort != requestedPort {
+		t.Fatalf("provider bound local_port %d, want the requested %d", localPort, requestedPort)
+	}
+
+	// terraform has exited, so the forked tunnel must self-terminate and free
+	// its local port (the WatchProcess half of the cross-OS process handling).
+	assertTunnelTerminated(t, "localhost", localPort)
+}
+
+// resolveKubeconfig returns the kubeconfig path from KUBECONFIG (first entry) or
+// ~/.kube/config, skipping the test when neither exists.
+func resolveKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	if kc := os.Getenv("KUBECONFIG"); kc != "" {
+		if first := strings.Split(kc, string(os.PathListSeparator))[0]; first != "" {
+			return first
+		}
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		def := filepath.Join(home, ".kube", "config")
+		if _, err := os.Stat(def); err == nil {
+			return def
+		}
+	}
+
+	t.Skip("no kubeconfig found (set KUBECONFIG or ~/.kube/config); skipping k8s E2E test")
+	return ""
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,205 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+)
+
+// providerDir is the directory containing the freshly built provider binary.
+// It is referenced by the Terraform dev_overrides config so that `terraform
+// apply` loads our local build instead of the released provider.
+var providerDir string
+
+func TestMain(m *testing.M) {
+	dir, err := buildProvider()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to build provider for e2e tests: %v\n", err)
+		os.Exit(1)
+	}
+	providerDir = dir
+	os.Exit(m.Run())
+}
+
+// repoRoot returns the module root, derived from this file's location so it is
+// independent of the test's working directory.
+func repoRoot() string {
+	_, file, _, _ := runtime.Caller(0)
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+// buildProvider compiles the provider into a temp directory named
+// terraform-provider-tunnel[.exe], matching the dev_overrides layout. We build
+// with CGO disabled to mirror the released (goreleaser) binary users actually run.
+func buildProvider() (string, error) {
+	dir := filepath.Join(os.TempDir(), "terraform-provider-tunnel-e2e")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+
+	bin := filepath.Join(dir, "terraform-provider-tunnel")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", bin, ".")
+	cmd.Dir = repoRoot()
+	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("go build: %w", err)
+	}
+	return dir, nil
+}
+
+// requireTerraform returns the path to the terraform binary, skipping the test
+// if it is not installed (e.g. local dev machines without Terraform).
+func requireTerraform(t *testing.T) string {
+	t.Helper()
+	tf, err := exec.LookPath("terraform")
+	if err != nil {
+		t.Skip("terraform not found in PATH; skipping E2E test")
+	}
+	return tf
+}
+
+// writeDevOverrides writes a CLI config that points the tunnel provider at our
+// local build. With dev_overrides in effect, `terraform apply` runs without
+// `terraform init` and without a dependency lock file.
+func writeDevOverrides(t *testing.T, dir string) string {
+	t.Helper()
+	// Use forward slashes so the path is valid inside an HCL string on Windows.
+	content := fmt.Sprintf(`
+provider_installation {
+  dev_overrides {
+    "dfns/tunnel" = %q
+  }
+  direct {}
+}
+`, filepath.ToSlash(providerDir))
+
+	path := filepath.Join(dir, "dev.tfrc")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing dev_overrides: %v", err)
+	}
+	return path
+}
+
+// terraformApply writes the given config into moduleDir and runs
+// `terraform apply -auto-approve`, failing the test on a non-zero exit code.
+// The whole run shares one terraform process, so any tunnel forked while the
+// data source is read stays alive until the local-exec verification has run.
+func terraformApply(t *testing.T, moduleDir, config string) {
+	t.Helper()
+	tf := requireTerraform(t)
+
+	if err := os.WriteFile(filepath.Join(moduleDir, "main.tf"), []byte(config), 0o644); err != nil {
+		t.Fatalf("writing main.tf: %v", err)
+	}
+	tfrc := writeDevOverrides(t, moduleDir)
+	logDir := filepath.Join(moduleDir, "tunnel-logs")
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		t.Fatalf("creating tunnel log dir: %v", err)
+	}
+
+	cmd := exec.Command(tf, "apply", "-auto-approve", "-no-color")
+	cmd.Dir = moduleDir
+	cmd.Env = append(os.Environ(),
+		"TF_CLI_CONFIG_FILE="+tfrc,
+		"TF_IN_AUTOMATION=1",
+		libs.TunnelLogDirEnv+"="+logDir,
+	)
+
+	out, err := cmd.CombinedOutput()
+	t.Logf("terraform apply output:\n%s", out)
+	if err != nil {
+		dumpTunnelLogs(t, logDir)
+		t.Fatalf("terraform apply failed: %v", err)
+	}
+}
+
+// dumpTunnelLogs reads and logs forked-tunnel log files from the explicit log
+// directory this test passed to the provider.
+func dumpTunnelLogs(t *testing.T, logDir string) {
+	t.Helper()
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		t.Logf("tunnel log dir %s: could not read: %v", logDir, err)
+		return
+	}
+	paths := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			paths = append(paths, filepath.Join(logDir, entry.Name()))
+		}
+	}
+	sort.Strings(paths)
+	if len(paths) == 0 {
+		t.Logf("tunnel log dir %s: no log files", logDir)
+		return
+	}
+
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		switch {
+		case err != nil:
+			t.Logf("tunnel log %s: could not read: %v", path, err)
+		case len(content) == 0:
+			// The child is torn down before flushing when the fork fails fast
+			t.Logf("tunnel log %s: empty (child terminated before writing any output)", path)
+		default:
+			t.Logf("--- tunnel log %s (%d bytes) ---\n%s", path, len(content), content)
+		}
+	}
+}
+
+// terraformOutput reads a root-level output value from the applied state.
+func terraformOutput(t *testing.T, moduleDir, name string) string {
+	t.Helper()
+	tf := requireTerraform(t)
+
+	cmd := exec.Command(tf, "output", "-raw", name)
+	cmd.Dir = moduleDir
+	cmd.Env = append(os.Environ(),
+		"TF_IN_AUTOMATION=1",
+	)
+
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("terraform output -raw %s: %v", name, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// assertTunnelTerminated verifies the forked tunnel process tore itself down
+// after terraform exited. Once the watched parent (terraform) is gone,
+// WatchProcess interrupts the child, which closes its local listener — so the
+// advertised local port becoming unreachable is the observable signal that the
+// forked process self-terminated rather than leaking.
+func assertTunnelTerminated(t *testing.T, localHost string, localPort int) {
+	t.Helper()
+	addr := net.JoinHostPort(localHost, strconv.Itoa(localPort))
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			return // listener gone → forked tunnel self-terminated
+		}
+		_ = conn.Close()
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("tunnel still accepting connections on %s after terraform exited; forked process did not self-terminate", addr)
+}

--- a/test/e2e/ssh_test.go
+++ b/test/e2e/ssh_test.go
@@ -1,0 +1,100 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+)
+
+const sshTargetBody = "tunnel-e2e-ok"
+
+// TestSSHTunnelE2E drives the tunnel_ssh data source end-to-end against an
+// in-process SSH bastion that local-forwards to an in-process HTTP target, then
+// asserts a real request flows through the tunnel. Runs on Linux, Windows and
+// macOS so the OS-specific fork/process-watch path is exercised on each.
+func TestSSHTunnelE2E(t *testing.T) {
+	// Target the SSH tunnel forwards to.
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, sshTargetBody)
+	}))
+	t.Cleanup(target.Close)
+	targetPort := mustURLPort(t, target.URL)
+
+	// Client key passed to the provider as PEM content, authorized on the server.
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	sshPort := sshtest.StartServer(t, authorizedKey)
+
+	moduleDir := t.TempDir()
+
+	config := fmt.Sprintf(`
+terraform {
+  required_providers {
+    tunnel = {
+      source = "dfns/tunnel"
+    }
+  }
+}
+
+data "tunnel_ssh" "t" {
+  ssh_host    = "127.0.0.1"
+  ssh_port    = %d
+  ssh_user    = %q
+  ssh_key     = <<EOT
+%sEOT
+  target_host = "127.0.0.1"
+  target_port = %d
+}
+
+resource "terraform_data" "probe" {
+  input = data.tunnel_ssh.t.local_port
+  provisioner "local-exec" {
+    command = "curl -fsS -o resp.txt http://${data.tunnel_ssh.t.local_host}:${data.tunnel_ssh.t.local_port}/"
+  }
+}
+
+output "local_port" {
+  value = data.tunnel_ssh.t.local_port
+}
+`, sshPort, sshtest.User, keyPEM, targetPort)
+
+	terraformApply(t, moduleDir, config)
+
+	got, err := os.ReadFile(filepath.Join(moduleDir, "resp.txt"))
+	if err != nil {
+		t.Fatalf("reading tunneled response: %v", err)
+	}
+	if string(got) != sshTargetBody {
+		t.Fatalf("tunnel returned %q, want %q", got, sshTargetBody)
+	}
+
+	// terraform has exited, so the forked tunnel must self-terminate and free
+	// its local port (the WatchProcess half of the cross-OS process handling).
+	localPort, err := strconv.Atoi(terraformOutput(t, moduleDir, "local_port"))
+	if err != nil {
+		t.Fatalf("parsing local_port output: %v", err)
+	}
+	assertTunnelTerminated(t, "localhost", localPort)
+}
+
+func mustURLPort(t *testing.T, raw string) int {
+	t.Helper()
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parsing %q: %v", raw, err)
+	}
+	p, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parsing port from %q: %v", raw, err)
+	}
+	return p
+}

--- a/test/integration/doc.go
+++ b/test/integration/doc.go
@@ -1,0 +1,7 @@
+// Package integration contains integration tests for the tunnel provider's
+// process-lifecycle primitives (the fork/watch machinery in internal/libs).
+//
+// This file is intentionally untagged so the package always has a buildable
+// Go file, keeping `go build ./...` and linters happy when the `integration`
+// build tag is absent. The tests themselves are guarded by that tag.
+package integration

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -1,0 +1,262 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/runner"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
+	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+)
+
+// Helper-process re-exec scaffold.
+//
+// To exercise the fork lifecycle and the process-lifecycle primitives against
+// real OS processes, the test binary re-execs itself before any tests run. It
+// recognizes two kinds of re-exec:
+//
+//   - The production fork: ForkRemoteTunnel runs exec.Command(os.Args[0], ppid)
+//     with libs.TunnelTypeEnv set, exactly as the released binary does. TestMain
+//     mirrors main.go's dispatch so the child becomes a real tunnel process.
+//   - Helper modes (selected by helperModeEnv): generic sleeper/watcher children
+//     used to drive the libs process primitives directly.
+const (
+	helperModeEnv = "TUNNEL_IT_HELPER_MODE"
+	watchPIDEnv   = "TUNNEL_IT_WATCH_PID"
+	listenPortEnv = "TUNNEL_IT_LISTEN_PORT"
+
+	// Config passed down to the forker helper for the parent-exit teardown test.
+	sshKeyEnv        = "TUNNEL_IT_SSH_KEY"
+	sshPortEnv       = "TUNNEL_IT_SSH_PORT"
+	localPortEnv     = "TUNNEL_IT_LOCAL_PORT"
+	targetPortEnv    = "TUNNEL_IT_TARGET_PORT"
+	forkerPidfileEnv = "TUNNEL_IT_FORKER_PIDFILE"
+
+	modeSleeper    = "sleeper"
+	modeWatcher    = "watcher"
+	modeForkParent = "forkparent"
+	modeForker     = "forker"
+)
+
+func TestMain(m *testing.M) {
+	// Production dispatch path: when re-executed by ForkRemoteTunnel, behave like
+	// the real provider binary's main() and run the requested tunnel in-process.
+	if tun := os.Getenv(libs.TunnelTypeEnv); tun != "" {
+		if err := runner.StartTunnel(tun); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	switch os.Getenv(helperModeEnv) {
+	case modeSleeper:
+		runSleeper()
+	case modeForkParent:
+		runForkParent()
+	case modeForker:
+		runForker()
+	case modeWatcher:
+		runWatcher()
+	default:
+		os.Exit(m.Run())
+	}
+}
+
+// runForkParent is the process the forked tunnel watches. It stands in for
+// terraform: it spawns the forker child (which forks the tunnel), reaps it, then
+// stays alive. Killing this process is what must tear the tunnel down.
+func runForkParent() {
+	cmd := exec.Command(os.Args[0])
+	// Override the inherited helper mode (Go's Getenv returns the first match,
+	// so the old value must be removed, not just shadowed) — otherwise this child
+	// would re-enter forkparent mode and fork forever.
+	cmd.Env = append(envWithout(os.Environ(), helperModeEnv), helperModeEnv+"="+modeForker)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "forkparent: starting forker: %v\n", err)
+		os.Exit(10)
+	}
+	// The forker exits as soon as it has forked the tunnel; reap it so it does
+	// not linger as a zombie under us.
+	_ = cmd.Wait()
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+// runForker forks a real SSH tunnel via ssh.ForkRemoteTunnel. Because
+// ForkRemoteTunnel passes os.Getppid() to the child, the tunnel ends up watching
+// this process's parent (the forkparent helper). It records the tunnel PID for
+// cleanup and exits — the tunnel keeps running, watching the forkparent.
+func runForker() {
+	sshPort, _ := strconv.Atoi(os.Getenv(sshPortEnv))
+	localPort, _ := strconv.Atoi(os.Getenv(localPortEnv))
+	targetPort, _ := strconv.Atoi(os.Getenv(targetPortEnv))
+
+	cmd, err := ssh.ForkRemoteTunnel(context.Background(), ssh.TunnelConfig{
+		LocalPort:  localPort,
+		SSHHost:    "127.0.0.1",
+		SSHPort:    sshPort,
+		SSHUser:    sshtest.User,
+		SSHKey:     os.Getenv(sshKeyEnv),
+		TargetHost: "127.0.0.1",
+		TargetPort: targetPort,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "forker: ForkRemoteTunnel: %v\n", err)
+		os.Exit(11)
+	}
+
+	if pidfile := os.Getenv(forkerPidfileEnv); pidfile != "" {
+		_ = os.WriteFile(pidfile, []byte(strconv.Itoa(cmd.Process.Pid)), 0o600)
+	}
+	os.Exit(0)
+}
+
+// envWithout returns a copy of env with any entry for key removed.
+func envWithout(env []string, key string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// runSleeper blocks until the process is signaled or killed by its parent. It
+// stands in for any long-lived process whose lifecycle the primitives observe.
+func runSleeper() {
+	for {
+		time.Sleep(time.Hour)
+	}
+}
+
+// runWatcher binds a listener (so the parent test can observe liveness through
+// the port) and then calls libs.WatchProcess on the watched PID. When that
+// watched process exits, WatchProcess signals this process, which terminates
+// and closes the listener — the observable teardown the fork model relies on.
+func runWatcher() {
+	watchPID, err := strconv.Atoi(os.Getenv(watchPIDEnv))
+	if err != nil {
+		os.Exit(2)
+	}
+
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", os.Getenv(listenPortEnv)))
+	if err != nil {
+		os.Exit(3)
+	}
+
+	if err := libs.WatchProcess(watchPID); err != nil {
+		os.Exit(4)
+	}
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		_ = conn.Close()
+	}
+}
+
+// spawnHelper re-execs this test binary in the given helper mode with the extra
+// environment provided, returning the started command. The helper is killed and
+// reaped on test cleanup so no child outlives the test.
+func spawnHelper(t *testing.T, mode string, env ...string) *exec.Cmd {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0])
+	// Replace (not just append) the helper mode so an inherited value can't win:
+	// Go's Getenv returns the first match for a duplicated key.
+	cmd.Env = append(envWithout(os.Environ(), helperModeEnv), helperModeEnv+"="+mode)
+	cmd.Env = append(cmd.Env, env...)
+	// Surface helper output in the test log if something goes wrong.
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting %s helper: %v", mode, err)
+	}
+	t.Cleanup(func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	return cmd
+}
+
+// requireEventually polls check until it returns nil or the timeout elapses,
+// failing with the last error so root causes surface in test output.
+func requireEventually(t *testing.T, timeout time.Duration, check func() error, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		lastErr = check()
+		if lastErr == nil {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	t.Fatalf("%s: %v", msg, lastErr)
+}
+
+// requireConsistently polls check for d and fails immediately if it returns an
+// error at any point.
+func requireConsistently(t *testing.T, d time.Duration, check func() error, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if err := check(); err != nil {
+			t.Fatalf("%s: %v", msg, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// requireStaysListening fails if addr stops accepting connections at any point
+// within d. Used to assert a watched child does NOT tear down while its parent
+// is still alive (on Windows the Status() stub makes WatchProcess do exactly
+// that on its first poll).
+func requireStaysListening(t *testing.T, addr string, d time.Duration) {
+	t.Helper()
+	requireConsistently(t, d, func() error { return checkPortReachable(addr) },
+		"listener went away while its watched parent was still alive (premature teardown)")
+}
+
+// checkPortReachable verifies a TCP connection to addr succeeds.
+func checkPortReachable(addr string) error {
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		return err
+	}
+	_ = conn.Close()
+	return nil
+}
+
+func checkPortClosed(addr string) error {
+	if err := checkPortReachable(addr); err != nil {
+		return nil
+	}
+	return fmt.Errorf("listener at %s still accepts connections", addr)
+}
+
+func checkProcessMissing(pid int) error {
+	if err := libs.CheckProcessExists(pid); err != nil {
+		return nil
+	}
+	return fmt.Errorf("process %d still exists", pid)
+}

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -1,0 +1,172 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
+	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+)
+
+const sshTargetBody = "tunnel-it-ok"
+
+// startSSHTarget stands up an in-process HTTP target and SSH bastion (both in
+// the test process), returning the bastion port, the target port, and the PEM
+// client key authorized on the bastion. Shared by the SSH fork tests.
+func startSSHTarget(t *testing.T) (sshPort, targetPort int, keyPEM string) {
+	t.Helper()
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, sshTargetBody)
+	}))
+	t.Cleanup(target.Close)
+
+	u, err := url.Parse(target.URL)
+	if err != nil {
+		t.Fatalf("parsing target URL %q: %v", target.URL, err)
+	}
+	targetPort, err = strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parsing target port from %q: %v", target.URL, err)
+	}
+
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	return sshtest.StartServer(t, authorizedKey), targetPort, keyPEM
+}
+
+// TestSSHForkRemoteTunnelLifecycle exercises the real fork contract without
+// terraform: ssh.ForkRemoteTunnel re-execs this binary (which TestMain turns
+// into a tunnel child via ssh.StartRemoteTunnel), packs the config and ready
+// file into the environment, and blocks until the child signals readiness.
+// We then push a real HTTP request through the forwarded local port, and tear
+// the tunnel down with libs.Interrupt — the exact call the provider's Close
+// uses — asserting the forked process releases its port.
+func TestSSHForkRemoteTunnelLifecycle(t *testing.T) {
+	sshPort, targetPort, keyPEM := startSSHTarget(t)
+
+	localPort, err := libs.GetFreePort()
+	if err != nil {
+		t.Fatalf("allocating local port: %v", err)
+	}
+
+	cmd, err := ssh.ForkRemoteTunnel(context.Background(), ssh.TunnelConfig{
+		LocalPort:  localPort,
+		SSHHost:    "127.0.0.1",
+		SSHPort:    sshPort,
+		SSHUser:    sshtest.User,
+		SSHKey:     keyPEM,
+		TargetHost: "127.0.0.1",
+		TargetPort: targetPort,
+	})
+	if err != nil {
+		t.Fatalf("ForkRemoteTunnel: %v", err)
+	}
+	// Safety net: make sure the forked child never outlives the test.
+	t.Cleanup(func() {
+		_ = libs.Interrupt(cmd.Process.Pid)
+		_ = cmd.Wait()
+	})
+
+	// ForkRemoteTunnel only returns after the ready handshake, so the tunnel is
+	// established: a request to the local port must reach the target through it.
+	localAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(fmt.Sprintf("http://%s/", localAddr))
+	if err != nil {
+		t.Fatalf("request through tunnel: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("reading tunneled response: %v", err)
+	}
+	if string(body) != sshTargetBody {
+		t.Fatalf("tunnel returned %q, want %q", body, sshTargetBody)
+	}
+
+	// Interrupt is the provider's Close path: the forked process must stop and
+	// release its local port.
+	if err := libs.Interrupt(cmd.Process.Pid); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	requireEventually(t, 15*time.Second, func() error { return checkPortClosed(localAddr) },
+		"forked tunnel still listening after Interrupt; it did not tear down")
+}
+
+// TestSSHForkParentExitTeardown wires the full fork chain to the WatchProcess
+// teardown that the Interrupt test cannot reach. ForkRemoteTunnel ties the
+// child to its forker's parent (os.Getppid), so a controllable tree is needed:
+//
+//	test ── forkparent helper ── forker helper ── ssh.ForkRemoteTunnel ── tunnel
+//	         (watched process)                                            (watches forkparent)
+//
+// Killing the forkparent helper simulates terraform exiting; the tunnel's own
+// WatchProcess (not a synthetic stand-in) must notice and self-terminate,
+// releasing the forwarded port. This is the production teardown path end-to-end.
+func TestSSHForkParentExitTeardown(t *testing.T) {
+	sshPort, targetPort, keyPEM := startSSHTarget(t)
+
+	localPort, err := libs.GetFreePort()
+	if err != nil {
+		t.Fatalf("allocating local port: %v", err)
+	}
+	pidfile := filepath.Join(t.TempDir(), "tunnel.pid")
+
+	parent := spawnHelper(t, modeForkParent,
+		sshKeyEnv+"="+keyPEM,
+		sshPortEnv+"="+strconv.Itoa(sshPort),
+		localPortEnv+"="+strconv.Itoa(localPort),
+		targetPortEnv+"="+strconv.Itoa(targetPort),
+		forkerPidfileEnv+"="+pidfile,
+	)
+	// If parent-exit teardown is broken, the tunnel child would leak — kill it.
+	t.Cleanup(func() {
+		if pid := readPidfile(pidfile); pid > 0 {
+			_ = libs.Interrupt(pid)
+		}
+	})
+
+	// The tunnel must come up through the full fork chain.
+	localAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(localPort))
+	requireEventually(t, 30*time.Second, func() error { return checkPortReachable(localAddr) },
+		"tunnel never became reachable through the fork chain")
+
+	// Simulate terraform dying. WatchProcess only fires once the watched PID is
+	// fully gone, so the killed parent must also be reaped.
+	if err := parent.Process.Kill(); err != nil {
+		t.Fatalf("killing forkparent: %v", err)
+	}
+	_ = parent.Wait()
+
+	// The tunnel's WatchProcess (2s poll) must self-terminate the forked child.
+	requireEventually(t, 20*time.Second, func() error { return checkPortClosed(localAddr) },
+		"tunnel still listening after its watched parent exited; WatchProcess did not tear it down")
+}
+
+// readPidfile reads a PID written by the forker helper, returning 0 if the file
+// is absent or unparseable.
+func readPidfile(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0
+	}
+	return pid
+}

--- a/test/integration/watch_test.go
+++ b/test/integration/watch_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package integration
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+)
+
+// TestWatchProcessTerminatesOnParentExit is the heart of the fork model: a
+// forked tunnel watches the terraform process and must tear itself down once
+// that parent goes away. Here a watcher helper monitors a separate "parent"
+// sleeper; killing the parent must make the watcher self-terminate, which we
+// observe through its listening port going dead.
+func TestWatchProcessTerminatesOnParentExit(t *testing.T) {
+	parent := spawnHelper(t, modeSleeper)
+
+	port, err := libs.GetFreePort()
+	if err != nil {
+		t.Fatalf("allocating free port: %v", err)
+	}
+
+	spawnHelper(t, modeWatcher,
+		watchPIDEnv+"="+strconv.Itoa(parent.Process.Pid),
+		listenPortEnv+"="+strconv.Itoa(port),
+	)
+
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	requireEventually(t, 10*time.Second, func() error { return checkPortReachable(addr) },
+		"watcher never started listening")
+
+	// Control: while the watched parent is alive, the watcher must KEEP
+	// listening. On Windows the Status() stub makes WatchProcess see a phantom
+	// "parent exited" on its first poll and tear the watcher down within
+	// milliseconds — this turns that into a deterministic failure instead of a
+	// false pass at the teardown assertion below.
+	requireStaysListening(t, addr, 3*time.Second)
+
+	// Kill and reap the watched parent so it disappears from the OS.
+	if err := parent.Process.Kill(); err != nil {
+		t.Fatalf("killing parent: %v", err)
+	}
+	_ = parent.Wait()
+
+	// WatchProcess polls every 2s; the watcher must notice and self-terminate.
+	requireEventually(t, 20*time.Second, func() error { return checkPortClosed(addr) },
+		"watcher still listening after its watched parent exited; it did not self-terminate")
+}
+
+// TestCheckProcessExists confirms a live child is reported as existing and a
+// killed one as gone.
+func TestCheckProcessExists(t *testing.T) {
+	sleeper := spawnHelper(t, modeSleeper)
+	pid := sleeper.Process.Pid
+
+	requireEventually(t, 5*time.Second, func() error { return libs.CheckProcessExists(pid) },
+		"live process reported as not existing")
+
+	if err := sleeper.Process.Kill(); err != nil {
+		t.Fatalf("killing sleeper: %v", err)
+	}
+	_ = sleeper.Wait()
+
+	requireEventually(t, 5*time.Second, func() error { return checkProcessMissing(pid) },
+		"process still reported alive after it was killed")
+}
+
+// TestInterruptTerminatesProcess confirms Interrupt actually stops the target
+// process (the Close path the provider uses to tear a tunnel down).
+func TestInterruptTerminatesProcess(t *testing.T) {
+	sleeper := spawnHelper(t, modeSleeper)
+	pid := sleeper.Process.Pid
+
+	requireEventually(t, 5*time.Second, func() error { return libs.CheckProcessExists(pid) },
+		"sleeper never became live")
+
+	if err := libs.Interrupt(pid); err != nil {
+		t.Fatalf("Interrupt: %v", err)
+	}
+	_ = sleeper.Wait() // reap after the interrupt terminates it
+
+	requireEventually(t, 5*time.Second, func() error { return checkProcessMissing(pid) },
+		"process still alive after Interrupt")
+}
+
+// TestWaitForPort covers the readiness probe SSM and Kubernetes forks use: it
+// returns once the port is reachable, and bails out immediately if the forked
+// process dies instead of blocking for the full timeout.
+func TestWaitForPort(t *testing.T) {
+	t.Run("returns once the port is reachable", func(t *testing.T) {
+		sleeper := spawnHelper(t, modeSleeper)
+
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listening: %v", err)
+		}
+		t.Cleanup(func() { _ = ln.Close() })
+		_, portStr, err := net.SplitHostPort(ln.Addr().String())
+		if err != nil {
+			t.Fatalf("splitting listener addr: %v", err)
+		}
+
+		if err := libs.WaitForPort(sleeper.Process.Pid, "127.0.0.1", portStr); err != nil {
+			t.Fatalf("WaitForPort: %v", err)
+		}
+	})
+
+	t.Run("fails fast when the process has exited", func(t *testing.T) {
+		sleeper := spawnHelper(t, modeSleeper)
+		pid := sleeper.Process.Pid
+		_ = sleeper.Process.Kill()
+		_ = sleeper.Wait()
+
+		port, err := libs.GetFreePort()
+		if err != nil {
+			t.Fatalf("allocating free port: %v", err)
+		}
+
+		start := time.Now()
+		err = libs.WaitForPort(pid, "127.0.0.1", strconv.Itoa(port))
+		if err == nil {
+			t.Fatal("expected an error once the process exited")
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Fatalf("WaitForPort did not fail fast: took %s", elapsed)
+		}
+	})
+}
+
+// TestWaitForReadyFile covers the readiness handshake the SSH fork uses: the
+// child SignalReady writes the sentinel file and WaitForReadyFile returns once
+// it appears, while a dead process aborts the wait promptly.
+func TestWaitForReadyFile(t *testing.T) {
+	t.Run("returns once the ready file exists", func(t *testing.T) {
+		sleeper := spawnHelper(t, modeSleeper)
+
+		path := filepath.Join(t.TempDir(), "ready")
+		if err := libs.SignalReady(path); err != nil {
+			t.Fatalf("SignalReady: %v", err)
+		}
+		if data, err := os.ReadFile(path); err != nil || string(data) != "ready" {
+			t.Fatalf("SignalReady wrote %q (err %v), want \"ready\"", data, err)
+		}
+
+		if err := libs.WaitForReadyFile(sleeper.Process.Pid, path); err != nil {
+			t.Fatalf("WaitForReadyFile: %v", err)
+		}
+	})
+
+	t.Run("fails fast when the process has exited", func(t *testing.T) {
+		sleeper := spawnHelper(t, modeSleeper)
+		pid := sleeper.Process.Pid
+		_ = sleeper.Process.Kill()
+		_ = sleeper.Wait()
+
+		path := filepath.Join(t.TempDir(), "ready") // never created
+
+		start := time.Now()
+		err := libs.WaitForReadyFile(pid, path)
+		if err == nil {
+			t.Fatal("expected an error once the process exited")
+		}
+		if elapsed := time.Since(start); elapsed > 10*time.Second {
+			t.Fatalf("WaitForReadyFile did not fail fast: took %s", elapsed)
+		}
+	})
+}


### PR DESCRIPTION
Introduces a three-tier test suite (unit, integration, end-to-end) that exercises the provider's tunnel fork/process-watch lifecycle across Linux, Windows, and macOS, along with the CI wiring to run each tier.

- Add unit tests for SSH target validation (`validateSSHTarget`), the binary entry-point dispatch (`runner.StartTunnel`), and the SSM session-input / SDK-config helpers.
- Add a `//go:build integration` suite under `test/integration/` that drives the real fork and `WatchProcess` primitives against live OS processes, covering the SSH fork lifecycle, parent-exit teardown, port/ready-file readiness probes, and process interrupt/exists checks.
- Add a `//go:build e2e` suite under `test/e2e/` that builds the provider and runs `terraform apply` against live fixtures — an in-process SSH bastion for `tunnel_ssh` and a kind cluster (CoreDNS metrics endpoint) for `tunnel_kubernetes` — asserting real traffic flows through the tunnel and the forked process self-terminates.
- Extract `StartTunnel` from `main.go` into a new `internal/runner` package so the integration tests can reuse the exact production dispatch path.
- Add an in-process SSH bastion test helper (`internal/sshtest`) that services `direct-tcpip` channels, build-tagged so it only compiles into test binaries.
- Add `libs.TunnelLogPath` / `TunnelLogDirEnv` to redirect forked-tunnel logs (used by e2e to capture child logs on failure), and route the ssh/ssm/k8s forks through it.
- Wrap process-exit errors with `%w` in `libs/watch.go` and the runner for better error chains.
- Rework the CI workflow into separate `unit`, `integration` (3 OSes), `ssh-e2e` (3 OSes), and `k8s-e2e` (kind) jobs, add concurrency cancellation and a push-to-`main` trigger, and bump Terraform to 1.10.5.
