### PR TITLE
feat: configurable local host and port for SSH and SSM

### DIFF
--- a/docs/data-sources/ssh.md
+++ b/docs/data-sources/ssh.md
@@ -42,6 +42,8 @@ provider "kubernetes" {
 
 ### Optional
 
+- `local_host` (String) The local address to listen on. Defaults to `localhost`.
+- `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
 - `ssh_key` (String, Sensitive) The path to the private key file or the private key content to use for the SSH connection
 - `ssh_key_passphrase` (String, Sensitive) The passphrase for the private key file
 - `ssh_password` (String, Sensitive) The password to use for the SSH connection
@@ -50,8 +52,3 @@ provider "kubernetes" {
 - `target_host` (String) The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.
 - `target_port` (Number) The TCP port of the remote host. Mutually exclusive with `target_socket`.
 - `target_socket` (String) Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.
-
-### Read-Only
-
-- `local_host` (String) The DNS name or IP address of the local host
-- `local_port` (Number) The local port number to use for the tunnel

--- a/docs/data-sources/ssm.md
+++ b/docs/data-sources/ssm.md
@@ -40,6 +40,7 @@ provider "postgresql" {
 
 ### Optional
 
+- `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.
@@ -47,4 +48,3 @@ provider "postgresql" {
 ### Read-Only
 
 - `local_host` (String) The DNS name or IP address of the local host
-- `local_port` (Number) The local port number to use for the tunnel

--- a/docs/ephemeral-resources/ssh.md
+++ b/docs/ephemeral-resources/ssh.md
@@ -42,6 +42,8 @@ provider "kubernetes" {
 
 ### Optional
 
+- `local_host` (String) The local address to listen on. Defaults to `localhost`.
+- `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
 - `ssh_key` (String, Sensitive) The path to the private key file or the private key content to use for the SSH connection
 - `ssh_key_passphrase` (String, Sensitive) The passphrase for the private key file
 - `ssh_password` (String, Sensitive) The password to use for the SSH connection
@@ -50,8 +52,3 @@ provider "kubernetes" {
 - `target_host` (String) The DNS name or IP address of the remote host. Required when `target_port` is set; ignored when `target_socket` is set.
 - `target_port` (Number) The TCP port of the remote host. Mutually exclusive with `target_socket`.
 - `target_socket` (String) Path of a unix domain socket on the SSH bastion to forward to. Mutually exclusive with `target_port`.
-
-### Read-Only
-
-- `local_host` (String) The DNS name or IP address of the local host
-- `local_port` (Number) The local port number to use for the tunnel

--- a/docs/ephemeral-resources/ssm.md
+++ b/docs/ephemeral-resources/ssm.md
@@ -40,6 +40,7 @@ provider "postgresql" {
 
 ### Optional
 
+- `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.
@@ -47,4 +48,3 @@ provider "postgresql" {
 ### Read-Only
 
 - `local_host` (String) The DNS name or IP address of the local host
-- `local_port` (Number) The local port number to use for the tunnel

--- a/internal/provider/data_source_ssh.go
+++ b/internal/provider/data_source_ssh.go
@@ -102,13 +102,14 @@ func (d *SSHDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Optional:            true,
 				Sensitive:           true,
 			},
-			// Computed attributes
 			"local_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the local host",
+				MarkdownDescription: "The local address to listen on. Defaults to `localhost`.",
+				Optional:            true,
 				Computed:            true,
 			},
 			"local_port": schema.Int64Attribute{
-				MarkdownDescription: "The local port number to use for the tunnel",
+				MarkdownDescription: "The local port to listen on. If not set, a random free port is chosen.",
+				Optional:            true,
 				Computed:            true,
 			},
 		},
@@ -130,14 +131,19 @@ func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	// Get a free port for the local tunnel
-	localPort, err := libs.GetFreePort()
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-		return
+	localPort := int(data.LocalPort.ValueInt64())
+	if localPort == 0 {
+		var err error
+		localPort, err = libs.GetFreePort()
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
+			return
+		}
 	}
 
-	data.LocalHost = types.StringValue("localhost")
+	if data.LocalHost.IsNull() {
+		data.LocalHost = types.StringValue("localhost")
+	}
 	data.LocalPort = types.Int64Value(int64(localPort))
 
 	if data.SSHUser.IsNull() {
@@ -152,7 +158,8 @@ func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		data.SSHPort = types.Int64Value(22)
 	}
 
-	_, err = ssh.ForkRemoteTunnel(ctx, ssh.TunnelConfig{
+	_, err := ssh.ForkRemoteTunnel(ctx, ssh.TunnelConfig{
+		LocalHost:        data.LocalHost.ValueString(),
 		LocalPort:        localPort,
 		SSHHost:          data.SSHHost.ValueString(),
 		SSHKey:           data.SSHKey.ValueString(),

--- a/internal/provider/data_source_ssm.go
+++ b/internal/provider/data_source_ssm.go
@@ -72,13 +72,14 @@ func (d *SSMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 				Computed:            true,
 			},
 
+			"local_port": schema.Int64Attribute{
+				MarkdownDescription: "The local port to listen on. If not set, a random free port is chosen.",
+				Optional:            true,
+				Computed:            true,
+			},
 			// Computed attributes
 			"local_host": schema.StringAttribute{
 				MarkdownDescription: "The DNS name or IP address of the local host",
-				Computed:            true,
-			},
-			"local_port": schema.Int64Attribute{
-				MarkdownDescription: "The local port number to use for the tunnel",
 				Computed:            true,
 			},
 		},
@@ -95,11 +96,14 @@ func (d *SSMDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	// Get a free port for the local tunnel
-	localPort, err := libs.GetFreePort()
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-		return
+	localPort := int(data.LocalPort.ValueInt64())
+	if localPort == 0 {
+		var err error
+		localPort, err = libs.GetFreePort()
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
+			return
+		}
 	}
 
 	// Hardcoded in session manager plugin

--- a/internal/provider/ephemeral_ssh.go
+++ b/internal/provider/ephemeral_ssh.go
@@ -88,13 +88,14 @@ func (d *SSHEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 				Optional:            true,
 				Sensitive:           true,
 			},
-			// Computed attributes
 			"local_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the local host",
+				MarkdownDescription: "The local address to listen on. Defaults to `localhost`.",
+				Optional:            true,
 				Computed:            true,
 			},
 			"local_port": schema.Int64Attribute{
-				MarkdownDescription: "The local port number to use for the tunnel",
+				MarkdownDescription: "The local port to listen on. If not set, a random free port is chosen.",
+				Optional:            true,
 				Computed:            true,
 			},
 		},
@@ -116,14 +117,19 @@ func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
-	// Get a free port for the local tunnel
-	localPort, err := libs.GetFreePort()
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-		return
+	localPort := int(data.LocalPort.ValueInt64())
+	if localPort == 0 {
+		var err error
+		localPort, err = libs.GetFreePort()
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
+			return
+		}
 	}
 
-	data.LocalHost = types.StringValue("localhost")
+	if data.LocalHost.IsNull() {
+		data.LocalHost = types.StringValue("localhost")
+	}
 	data.LocalPort = types.Int64Value(int64(localPort))
 
 	if data.SSHUser.IsNull() {
@@ -139,6 +145,7 @@ func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 	}
 
 	cmd, err := ssh.ForkRemoteTunnel(ctx, ssh.TunnelConfig{
+		LocalHost:        data.LocalHost.ValueString(),
 		LocalPort:        localPort,
 		SSHHost:          data.SSHHost.ValueString(),
 		SSHKey:           data.SSHKey.ValueString(),

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -71,14 +71,14 @@ func (d *SSMEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 				Optional:            true,
 				Computed:            true,
 			},
-
+			"local_port": schema.Int64Attribute{
+				MarkdownDescription: "The local port to listen on. If not set, a random free port is chosen.",
+				Optional:            true,
+				Computed:            true,
+			},
 			// Computed attributes
 			"local_host": schema.StringAttribute{
 				MarkdownDescription: "The DNS name or IP address of the local host",
-				Computed:            true,
-			},
-			"local_port": schema.Int64Attribute{
-				MarkdownDescription: "The local port number to use for the tunnel",
 				Computed:            true,
 			},
 		},
@@ -95,11 +95,14 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
-	// Get a free port for the local tunnel
-	localPort, err := libs.GetFreePort()
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-		return
+	localPort := int(data.LocalPort.ValueInt64())
+	if localPort == 0 {
+		var err error
+		localPort, err = libs.GetFreePort()
+		if err != nil {
+			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
+			return
+		}
 	}
 
 	// Hardcoded in session manager plugin

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -21,6 +21,7 @@ import (
 var TunnelType string = "ssh"
 
 type TunnelConfig struct {
+	LocalHost        string
 	LocalPort        int
 	SSHHost          string
 	SSHKey           string
@@ -94,15 +95,21 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 		return err
 	}
 
+	localHost := cfg.LocalHost
+	if localHost == "" {
+		localHost = "localhost"
+	}
+
 	target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
 	if cfg.TargetSocket != "" {
 		target = cfg.TargetSocket
 	}
-	log.Printf("starting tunnel: localhost:%d - %s:%d - %s", cfg.LocalPort, cfg.SSHHost, cfg.SSHPort, target)
+	log.Printf("starting tunnel: %s:%d - %s:%d - %s", localHost, cfg.LocalPort, cfg.SSHHost, cfg.SSHPort, target)
 
 	sshTun := sshtun.New(cfg.LocalPort, cfg.SSHHost, cfg.TargetPort)
 	sshTun.SetPort(cfg.SSHPort)
 	sshTun.SetUser(cfg.SSHUser)
+	sshTun.SetLocalHost(localHost)
 	if cfg.TargetSocket != "" {
 		sshTun.SetRemoteEndpoint(sshtun.NewUnixEndpoint(cfg.TargetSocket))
 	} else {
@@ -154,7 +161,8 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 			// when the first connection is handled. We wait for TunneledConnState
 			// with Ready=true to know the full tunnel (SSH + remote) is established.
 			go func() {
-				conn, err := net.DialTimeout("tcp", net.JoinHostPort("localhost", strconv.Itoa(cfg.LocalPort)), 30*time.Second)
+				addr := net.JoinHostPort(localHost, strconv.Itoa(cfg.LocalPort))
+				conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
 				if err != nil {
 					log.Printf("tunnel probe dial failed: %v", err)
 					return

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -64,6 +64,7 @@ func TestSSHForkRemoteTunnelLifecycle(t *testing.T) {
 	}
 
 	cmd, err := ssh.ForkRemoteTunnel(context.Background(), ssh.TunnelConfig{
+		LocalHost:  "127.0.0.1", // exercise the configurable bind address
 		LocalPort:  localPort,
 		SSHHost:    "127.0.0.1",
 		SSHPort:    sshPort,


### PR DESCRIPTION
This PR makes the tunnel's local endpoint configurable instead of always binding to `localhost` on a random free port.