### PR TITLE
Allow custom SSM Document

### DIFF
--- a/docs/data-sources/ssm.md
+++ b/docs/data-sources/ssm.md
@@ -41,6 +41,7 @@ provider "postgresql" {
 ### Optional
 
 - `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
+- `ssm_document` (String) Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.

--- a/docs/data-sources/ssm.md
+++ b/docs/data-sources/ssm.md
@@ -35,7 +35,6 @@ provider "postgresql" {
 ### Required
 
 - `ssm_instance` (String) Specify the exact Instance ID of the managed node to connect to for the session
-- `target_host` (String) The DNS name or IP address of the remote host
 - `target_port` (Number) The port number of the remote host
 
 ### Optional
@@ -45,6 +44,7 @@ provider "postgresql" {
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.
+- `target_host` (String) The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.
 
 ### Read-Only
 

--- a/docs/data-sources/ssm.md
+++ b/docs/data-sources/ssm.md
@@ -35,15 +35,16 @@ provider "postgresql" {
 ### Required
 
 - `ssm_instance` (String) Specify the exact Instance ID of the managed node to connect to for the session
-- `target_host` (String) The DNS name or IP address of the remote host
-- `target_port` (Number) The port number of the remote host
 
 ### Optional
 
 - `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
+- `ssm_document` (String) Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.
+- `target_host` (String) The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.
+- `target_port` (Number) The port number of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed port.
 
 ### Read-Only
 

--- a/docs/ephemeral-resources/ssm.md
+++ b/docs/ephemeral-resources/ssm.md
@@ -41,6 +41,7 @@ provider "postgresql" {
 ### Optional
 
 - `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
+- `ssm_document` (String) Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.

--- a/docs/ephemeral-resources/ssm.md
+++ b/docs/ephemeral-resources/ssm.md
@@ -35,15 +35,16 @@ provider "postgresql" {
 ### Required
 
 - `ssm_instance` (String) Specify the exact Instance ID of the managed node to connect to for the session
-- `target_host` (String) The DNS name or IP address of the remote host
-- `target_port` (Number) The port number of the remote host
 
 ### Optional
 
 - `local_port` (Number) The local port to listen on. If not set, a random free port is chosen.
+- `ssm_document` (String) Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.
 - `ssm_profile` (String) AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.
 - `ssm_region` (String) AWS Region where the instance is located. The Region must be set. Can also be set using either the environment variables `AWS_REGION` or `AWS_DEFAULT_REGION`.
 - `ssm_role_arn` (String) ARN of an IAM role to assume.
+- `target_host` (String) The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.
+- `target_port` (Number) The port number of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed port.
 
 ### Read-Only
 

--- a/internal/provider/data_source_ssm.go
+++ b/internal/provider/data_source_ssm.go
@@ -27,6 +27,7 @@ type SSMDataSourceModel struct {
 	LocalHost   types.String `tfsdk:"local_host"`
 	LocalPort   types.Int64  `tfsdk:"local_port"`
 	SSMInstance types.String `tfsdk:"ssm_instance"`
+	SSMDocument types.String `tfsdk:"ssm_document"`
 	SSMProfile  types.String `tfsdk:"ssm_profile"`
 	SSMRoleARN  types.String `tfsdk:"ssm_role_arn"`
 	SSMRegion   types.String `tfsdk:"ssm_region"`
@@ -43,18 +44,21 @@ func (d *SSMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 		MarkdownDescription: "Create a local AWS SSM tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
-				MarkdownDescription: "The port number of the remote host",
-				Required:            true,
+				MarkdownDescription: "The port number of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed port.",
+				Optional:            true,
 			},
 			"ssm_instance": schema.StringAttribute{
 				MarkdownDescription: "Specify the exact Instance ID of the managed node to connect to for the session",
 				Required:            true,
+			},
+			"ssm_document": schema.StringAttribute{
+				MarkdownDescription: "Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.",
+				Optional:            true,
 			},
 			"ssm_profile": schema.StringAttribute{
 				MarkdownDescription: "AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.",
@@ -96,6 +100,11 @@ func (d *SSMDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
+	appendSSMTunnelValidationDiagnostics(&resp.Diagnostics, data.TargetHost, data.TargetPort, data.SSMDocument)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	localPort := int(data.LocalPort.ValueInt64())
 	if localPort == 0 {
 		var err error
@@ -114,11 +123,12 @@ func (d *SSMDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	tunnelCfg := ssm.TunnelConfig{
 		LocalPort:   strconv.Itoa(localPort),
 		SSMInstance: data.SSMInstance.ValueString(),
+		SSMDocument: data.SSMDocument.ValueString(),
 		SSMProfile:  data.SSMProfile.ValueString(),
 		SSMRoleARN:  data.SSMRoleARN.ValueString(),
 		SSMRegion:   data.SSMRegion.ValueString(),
 		TargetHost:  data.TargetHost.ValueString(),
-		TargetPort:  strconv.Itoa(int(data.TargetPort.ValueInt64())),
+		TargetPort:  ssmTargetPortString(data.TargetPort),
 	}
 
 	awsCfg, err := ssm.GetNewSDKConfig(ctx, tunnelCfg)

--- a/internal/provider/data_source_ssm.go
+++ b/internal/provider/data_source_ssm.go
@@ -27,6 +27,7 @@ type SSMDataSourceModel struct {
 	LocalHost   types.String `tfsdk:"local_host"`
 	LocalPort   types.Int64  `tfsdk:"local_port"`
 	SSMInstance types.String `tfsdk:"ssm_instance"`
+	SSMDocument types.String `tfsdk:"ssm_document"`
 	SSMProfile  types.String `tfsdk:"ssm_profile"`
 	SSMRoleARN  types.String `tfsdk:"ssm_role_arn"`
 	SSMRegion   types.String `tfsdk:"ssm_region"`
@@ -55,6 +56,10 @@ func (d *SSMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 			"ssm_instance": schema.StringAttribute{
 				MarkdownDescription: "Specify the exact Instance ID of the managed node to connect to for the session",
 				Required:            true,
+			},
+			"ssm_document": schema.StringAttribute{
+				MarkdownDescription: "Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.",
+				Optional:            true,
 			},
 			"ssm_profile": schema.StringAttribute{
 				MarkdownDescription: "AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.",
@@ -114,6 +119,7 @@ func (d *SSMDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	tunnelCfg := ssm.TunnelConfig{
 		LocalPort:   strconv.Itoa(localPort),
 		SSMInstance: data.SSMInstance.ValueString(),
+		SSMDocument: data.SSMDocument.ValueString(),
 		SSMProfile:  data.SSMProfile.ValueString(),
 		SSMRoleARN:  data.SSMRoleARN.ValueString(),
 		SSMRegion:   data.SSMRegion.ValueString(),

--- a/internal/provider/data_source_ssm.go
+++ b/internal/provider/data_source_ssm.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -11,6 +12,17 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
+
+func validateSSMTarget(targetHost, ssmDocument types.String) error {
+	doc := ssmDocument.ValueString()
+	if doc != "" && doc != ssm.DefaultSSMDocument {
+		return nil
+	}
+	if targetHost.IsNull() || targetHost.ValueString() == "" {
+		return errors.New("`target_host` is required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`")
+	}
+	return nil
+}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &SSMDataSource{}
@@ -44,10 +56,9 @@ func (d *SSMDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 		MarkdownDescription: "Create a local AWS SSM tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
 				MarkdownDescription: "The port number of the remote host",
@@ -98,6 +109,14 @@ func (d *SSMDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validateSSMTarget(data.TargetHost, data.SSMDocument); err != nil {
+		resp.Diagnostics.AddError(
+			"target_host is required for the default SSM port-forwarding document",
+			err.Error(),
+		)
 		return
 	}
 

--- a/internal/provider/data_source_ssm_test.go
+++ b/internal/provider/data_source_ssm_test.go
@@ -1,0 +1,70 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/ssm"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestValidateSSMTarget exercises target_host requirements for the default SSM
+// document and the relaxed rules when a custom document is used.
+func TestValidateSSMTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetHost  types.String
+		ssmDocument types.String
+		wantErr     string
+	}{
+		{
+			name:        "default document with host is valid",
+			targetHost:  types.StringValue("db.internal"),
+			ssmDocument: types.StringNull(),
+		},
+		{
+			name:        "explicit default document with host is valid",
+			targetHost:  types.StringValue("db.internal"),
+			ssmDocument: types.StringValue(ssm.DefaultSSMDocument),
+		},
+		{
+			name:        "custom document without host is valid",
+			ssmDocument: types.StringValue("My-Custom-PortForwardDoc"),
+		},
+		{
+			name:        "custom document with host is valid",
+			targetHost:  types.StringValue("db.internal"),
+			ssmDocument: types.StringValue("My-Custom-PortForwardDoc"),
+		},
+		{
+			name:        "default document without host",
+			ssmDocument: types.StringNull(),
+			wantErr:     "`target_host` is required",
+		},
+		{
+			name:        "default document with empty host",
+			targetHost:  types.StringValue(""),
+			ssmDocument: types.StringNull(),
+			wantErr:     "`target_host` is required",
+		},
+		{
+			name:        "explicit default document without host",
+			ssmDocument: types.StringValue(ssm.DefaultSSMDocument),
+			wantErr:     "`target_host` is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSSMTarget(tt.targetHost, tt.ssmDocument)
+			switch {
+			case tt.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tt.wantErr != "" && err == nil:
+				t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+			case tt.wantErr != "" && !strings.Contains(err.Error(), tt.wantErr):
+				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -27,6 +27,7 @@ type SSMEphemeralModel struct {
 	LocalHost   types.String `tfsdk:"local_host"`
 	LocalPort   types.Int64  `tfsdk:"local_port"`
 	SSMInstance types.String `tfsdk:"ssm_instance"`
+	SSMDocument types.String `tfsdk:"ssm_document"`
 	SSMProfile  types.String `tfsdk:"ssm_profile"`
 	SSMRoleARN  types.String `tfsdk:"ssm_role_arn"`
 	SSMRegion   types.String `tfsdk:"ssm_region"`
@@ -55,6 +56,10 @@ func (d *SSMEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 			"ssm_instance": schema.StringAttribute{
 				MarkdownDescription: "Specify the exact Instance ID of the managed node to connect to for the session",
 				Required:            true,
+			},
+			"ssm_document": schema.StringAttribute{
+				MarkdownDescription: "Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.",
+				Optional:            true,
 			},
 			"ssm_profile": schema.StringAttribute{
 				MarkdownDescription: "AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.",
@@ -113,6 +118,7 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 	tunnelCfg := ssm.TunnelConfig{
 		LocalPort:   strconv.Itoa(localPort),
 		SSMInstance: data.SSMInstance.ValueString(),
+		SSMDocument: data.SSMDocument.ValueString(),
 		SSMProfile:  data.SSMProfile.ValueString(),
 		SSMRoleARN:  data.SSMRoleARN.ValueString(),
 		SSMRegion:   data.SSMRegion.ValueString(),

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -44,10 +44,9 @@ func (d *SSMEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 		MarkdownDescription: "Create a local AWS SSM tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
 				MarkdownDescription: "The port number of the remote host",
@@ -97,6 +96,14 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
 	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := validateSSMTarget(data.TargetHost, data.SSMDocument); err != nil {
+		resp.Diagnostics.AddError(
+			"target_host is required for the default SSM port-forwarding document",
+			err.Error(),
+		)
 		return
 	}
 

--- a/internal/provider/ephemeral_ssm.go
+++ b/internal/provider/ephemeral_ssm.go
@@ -27,6 +27,7 @@ type SSMEphemeralModel struct {
 	LocalHost   types.String `tfsdk:"local_host"`
 	LocalPort   types.Int64  `tfsdk:"local_port"`
 	SSMInstance types.String `tfsdk:"ssm_instance"`
+	SSMDocument types.String `tfsdk:"ssm_document"`
 	SSMProfile  types.String `tfsdk:"ssm_profile"`
 	SSMRoleARN  types.String `tfsdk:"ssm_role_arn"`
 	SSMRegion   types.String `tfsdk:"ssm_region"`
@@ -43,18 +44,21 @@ func (d *SSMEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 		MarkdownDescription: "Create a local AWS SSM tunnel to a remote host",
 
 		Attributes: map[string]schema.Attribute{
-			// Required attributes
 			"target_host": schema.StringAttribute{
-				MarkdownDescription: "The DNS name or IP address of the remote host",
-				Required:            true,
+				MarkdownDescription: "The DNS name or IP address of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed host.",
+				Optional:            true,
 			},
 			"target_port": schema.Int64Attribute{
-				MarkdownDescription: "The port number of the remote host",
-				Required:            true,
+				MarkdownDescription: "The port number of the remote host. Required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`; omit when using a custom document that defines a fixed port.",
+				Optional:            true,
 			},
 			"ssm_instance": schema.StringAttribute{
 				MarkdownDescription: "Specify the exact Instance ID of the managed node to connect to for the session",
 				Required:            true,
+			},
+			"ssm_document": schema.StringAttribute{
+				MarkdownDescription: "Name of the SSM Session document to use for port forwarding. Defaults to `AWS-StartPortForwardingSessionToRemoteHost` when unset.",
+				Optional:            true,
 			},
 			"ssm_profile": schema.StringAttribute{
 				MarkdownDescription: "AWS profile name as set in credentials files. Can also be set using either the environment variables `AWS_PROFILE` or `AWS_DEFAULT_PROFILE`.",
@@ -95,6 +99,11 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
+	appendSSMTunnelValidationDiagnostics(&resp.Diagnostics, data.TargetHost, data.TargetPort, data.SSMDocument)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	localPort := int(data.LocalPort.ValueInt64())
 	if localPort == 0 {
 		var err error
@@ -113,11 +122,12 @@ func (d *SSMEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 	tunnelCfg := ssm.TunnelConfig{
 		LocalPort:   strconv.Itoa(localPort),
 		SSMInstance: data.SSMInstance.ValueString(),
+		SSMDocument: data.SSMDocument.ValueString(),
 		SSMProfile:  data.SSMProfile.ValueString(),
 		SSMRoleARN:  data.SSMRoleARN.ValueString(),
 		SSMRegion:   data.SSMRegion.ValueString(),
 		TargetHost:  data.TargetHost.ValueString(),
-		TargetPort:  strconv.Itoa(int(data.TargetPort.ValueInt64())),
+		TargetPort:  ssmTargetPortString(data.TargetPort),
 	}
 
 	awsCfg, err := ssm.GetNewSDKConfig(ctx, tunnelCfg)

--- a/internal/provider/ssm_validation.go
+++ b/internal/provider/ssm_validation.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/ssm"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func validateSSMTunnel(targetHost types.String, targetPort types.Int64, ssmDocument types.String) []error {
+	doc := ssmDocument.ValueString()
+	if doc != "" && doc != ssm.DefaultSSMDocument {
+		return nil
+	}
+
+	var errs []error
+	if targetHost.IsNull() || targetHost.ValueString() == "" {
+		errs = append(errs, errors.New("`target_host` is required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`"))
+	}
+	if targetPort.IsNull() || targetPort.ValueInt64() == 0 {
+		errs = append(errs, errors.New("`target_port` is required when `ssm_document` is unset or set to `AWS-StartPortForwardingSessionToRemoteHost`"))
+	}
+	return errs
+}
+
+func appendSSMTunnelValidationDiagnostics(diags *diag.Diagnostics, targetHost types.String, targetPort types.Int64, ssmDocument types.String) {
+	for _, err := range validateSSMTunnel(targetHost, targetPort, ssmDocument) {
+		switch {
+		case strings.Contains(err.Error(), "`target_host`"):
+			diags.AddError(
+				"target_host is required for the default SSM port-forwarding document",
+				err.Error(),
+			)
+		case strings.Contains(err.Error(), "`target_port`"):
+			diags.AddError(
+				"target_port is required for the default SSM port-forwarding document",
+				err.Error(),
+			)
+		default:
+			diags.AddError("Invalid SSM tunnel configuration", err.Error())
+		}
+	}
+}
+
+func ssmTargetPortString(port types.Int64) string {
+	if port.IsNull() || port.ValueInt64() == 0 {
+		return ""
+	}
+	return strconv.Itoa(int(port.ValueInt64()))
+}

--- a/internal/provider/ssm_validation_test.go
+++ b/internal/provider/ssm_validation_test.go
@@ -1,0 +1,130 @@
+package provider
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/ssm"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// TestValidateSSMTunnel exercises target_host and target_port requirements for the
+// default SSM document and the relaxed rules when a custom document is used.
+func TestValidateSSMTunnel(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetHost  types.String
+		targetPort  types.Int64
+		ssmDocument types.String
+		wantErrs    []string
+	}{
+		{
+			name:        "default document with host and port is valid",
+			targetHost:  types.StringValue("db.internal"),
+			targetPort:  types.Int64Value(5432),
+			ssmDocument: types.StringNull(),
+		},
+		{
+			name:        "explicit default document with host and port is valid",
+			targetHost:  types.StringValue("db.internal"),
+			targetPort:  types.Int64Value(5432),
+			ssmDocument: types.StringValue(ssm.DefaultSSMDocument),
+		},
+		{
+			name:        "custom document without host or port is valid",
+			ssmDocument: types.StringValue("My-Custom-PortForwardDoc"),
+		},
+		{
+			name:        "custom document with host and port is valid",
+			targetHost:  types.StringValue("db.internal"),
+			targetPort:  types.Int64Value(5432),
+			ssmDocument: types.StringValue("My-Custom-PortForwardDoc"),
+		},
+		{
+			name:        "default document without host",
+			targetPort:  types.Int64Value(5432),
+			ssmDocument: types.StringNull(),
+			wantErrs:    []string{"`target_host` is required"},
+		},
+		{
+			name:        "default document without port",
+			targetHost:  types.StringValue("db.internal"),
+			ssmDocument: types.StringNull(),
+			wantErrs:    []string{"`target_port` is required"},
+		},
+		{
+			name:        "default document without host or port",
+			ssmDocument: types.StringNull(),
+			wantErrs:    []string{"`target_host` is required", "`target_port` is required"},
+		},
+		{
+			name:        "default document with empty host",
+			targetHost:  types.StringValue(""),
+			targetPort:  types.Int64Value(5432),
+			ssmDocument: types.StringNull(),
+			wantErrs:    []string{"`target_host` is required"},
+		},
+		{
+			name:        "default document with zero port",
+			targetHost:  types.StringValue("db.internal"),
+			targetPort:  types.Int64Value(0),
+			ssmDocument: types.StringNull(),
+			wantErrs:    []string{"`target_port` is required"},
+		},
+		{
+			name:        "explicit default document without host or port",
+			ssmDocument: types.StringValue(ssm.DefaultSSMDocument),
+			wantErrs:    []string{"`target_host` is required", "`target_port` is required"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			errs := validateSSMTunnel(tt.targetHost, tt.targetPort, tt.ssmDocument)
+			switch {
+			case len(tt.wantErrs) == 0 && len(errs) > 0:
+				t.Fatalf("unexpected errors: %v", errs)
+			case len(tt.wantErrs) > 0 && len(errs) != len(tt.wantErrs):
+				t.Fatalf("got %d errors %v, want %d errors containing %v", len(errs), errs, len(tt.wantErrs), tt.wantErrs)
+			default:
+				for i, wantErr := range tt.wantErrs {
+					if !strings.Contains(errs[i].Error(), wantErr) {
+						t.Fatalf("error %q does not contain %q", errs[i], wantErr)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestSSMTargetPortString(t *testing.T) {
+	tests := []struct {
+		name string
+		port types.Int64
+		want string
+	}{
+		{
+			name: "null port",
+			port: types.Int64Null(),
+			want: "",
+		},
+		{
+			name: "zero port",
+			port: types.Int64Value(0),
+			want: "",
+		},
+		{
+			name: "valid port",
+			port: types.Int64Value(5432),
+			want: "5432",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ssmTargetPortString(tt.port); got != tt.want {
+				t.Fatalf("ssmTargetPortString() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ssm/session.go
+++ b/internal/ssm/session.go
@@ -12,9 +12,13 @@ import (
 
 const DEFAULT_SSM_ENV_NAME = "AWS_SSM_START_SESSION_RESPONSE"
 
+// Default SSM document for port forwarding.
+const DefaultSSMDocument = "AWS-StartPortForwardingSessionToRemoteHost"
+
 type TunnelConfig struct {
 	LocalPort   string
 	SSMInstance string
+	SSMDocument string
 	SSMProfile  string
 	SSMRoleARN  string
 	SSMRegion   string
@@ -73,13 +77,24 @@ func GetSDKConfigRole(awsCfg aws.Config) string {
 
 func CreateSessionInput(cfg TunnelConfig) ssm.StartSessionInput {
 	reqParams := make(map[string][]string)
-	reqParams["portNumber"] = []string{cfg.TargetPort}
 	reqParams["localPortNumber"] = []string{cfg.LocalPort}
-	reqParams["host"] = []string{cfg.TargetHost}
+
+	docName := cfg.SSMDocument
+	if docName == "" {
+		docName = DefaultSSMDocument
+	}
+
+	if cfg.TargetHost != "" {
+		reqParams["host"] = []string{cfg.TargetHost}
+	}
+
+	if cfg.TargetPort != "" {
+		reqParams["portNumber"] = []string{cfg.TargetPort}
+	}
 
 	return ssm.StartSessionInput{
 		Target:       aws.String(cfg.SSMInstance),
-		DocumentName: aws.String("AWS-StartPortForwardingSessionToRemoteHost"),
+		DocumentName: aws.String(docName),
 		Parameters:   reqParams,
 	}
 }

--- a/internal/ssm/session.go
+++ b/internal/ssm/session.go
@@ -12,9 +12,13 @@ import (
 
 const DEFAULT_SSM_ENV_NAME = "AWS_SSM_START_SESSION_RESPONSE"
 
+// Default SSM document for port forwarding.
+const DefaultSSMDocument = "AWS-StartPortForwardingSessionToRemoteHost"
+
 type TunnelConfig struct {
 	LocalPort   string
 	SSMInstance string
+	SSMDocument string
 	SSMProfile  string
 	SSMRoleARN  string
 	SSMRegion   string
@@ -77,9 +81,14 @@ func CreateSessionInput(cfg TunnelConfig) ssm.StartSessionInput {
 	reqParams["localPortNumber"] = []string{cfg.LocalPort}
 	reqParams["host"] = []string{cfg.TargetHost}
 
+	docName := cfg.SSMDocument
+	if docName == "" {
+		docName = DefaultSSMDocument
+	}
+
 	return ssm.StartSessionInput{
 		Target:       aws.String(cfg.SSMInstance),
-		DocumentName: aws.String("AWS-StartPortForwardingSessionToRemoteHost"),
+		DocumentName: aws.String(docName),
 		Parameters:   reqParams,
 	}
 }

--- a/internal/ssm/session.go
+++ b/internal/ssm/session.go
@@ -79,11 +79,14 @@ func CreateSessionInput(cfg TunnelConfig) ssm.StartSessionInput {
 	reqParams := make(map[string][]string)
 	reqParams["portNumber"] = []string{cfg.TargetPort}
 	reqParams["localPortNumber"] = []string{cfg.LocalPort}
-	reqParams["host"] = []string{cfg.TargetHost}
 
 	docName := cfg.SSMDocument
 	if docName == "" {
 		docName = DefaultSSMDocument
+	}
+
+	if cfg.TargetHost != "" {
+		reqParams["host"] = []string{cfg.TargetHost}
 	}
 
 	return ssm.StartSessionInput{

--- a/internal/ssm/session_test.go
+++ b/internal/ssm/session_test.go
@@ -8,39 +8,110 @@ import (
 )
 
 // TestCreateSessionInput verifies the AWS port-forwarding request is assembled
-// from the tunnel config: the document name is fixed and the three parameters
-// map to the configured target port, local port and host.
+// from the tunnel config: the document name defaults or follows SSMDocument,
+// localPort is always set, and host/port are included only when configured.
 func TestCreateSessionInput(t *testing.T) {
-	cfg := TunnelConfig{
-		LocalPort:   "12345",
-		SSMInstance: "i-0abc123",
-		TargetHost:  "db.internal",
-		TargetPort:  "5432",
-	}
-
-	in := CreateSessionInput(cfg)
-
-	if in.Target == nil || *in.Target != cfg.SSMInstance {
-		t.Errorf("Target = %v, want %q", in.Target, cfg.SSMInstance)
-	}
-	if in.DocumentName == nil || *in.DocumentName != "AWS-StartPortForwardingSessionToRemoteHost" {
-		t.Errorf("DocumentName = %v, want AWS-StartPortForwardingSessionToRemoteHost", in.DocumentName)
-	}
-
-	wantParams := map[string]string{
-		"portNumber":      "5432",
-		"localPortNumber": "12345",
-		"host":            "db.internal",
-	}
-	for key, want := range wantParams {
-		got, ok := in.Parameters[key]
-		if !ok {
-			t.Errorf("missing parameter %q", key)
-			continue
+	t.Run("default document when SSMDocument is empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			TargetHost:  "db.internal",
+			TargetPort:  "5432",
 		}
-		if len(got) != 1 || got[0] != want {
-			t.Errorf("parameter %q = %v, want [%q]", key, got, want)
+
+		in := CreateSessionInput(cfg)
+
+		if in.Target == nil || *in.Target != cfg.SSMInstance {
+			t.Errorf("Target = %v, want %q", in.Target, cfg.SSMInstance)
 		}
+		if in.DocumentName == nil || *in.DocumentName != DefaultSSMDocument {
+			t.Errorf("DocumentName = %v, want %q", in.DocumentName, DefaultSSMDocument)
+		}
+
+		assertPortForwardParams(t, in.Parameters, "5432", "db.internal")
+	})
+
+	t.Run("custom SSMDocument", func(t *testing.T) {
+		const customDoc = "My-Custom-PortForwardDoc"
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: customDoc,
+			TargetHost:  "db.internal",
+			TargetPort:  "5432",
+		}
+
+		in := CreateSessionInput(cfg)
+		if in.DocumentName == nil || *in.DocumentName != customDoc {
+			t.Errorf("DocumentName = %v, want %q", in.DocumentName, customDoc)
+		}
+		assertPortForwardParams(t, in.Parameters, "5432", "db.internal")
+	})
+
+	t.Run("omits host when TargetHost is empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: "My-Custom-PortForwardDoc",
+			TargetPort:  "5432",
+		}
+
+		in := CreateSessionInput(cfg)
+		assertPortForwardParams(t, in.Parameters, "5432", "")
+	})
+
+	t.Run("omits port when TargetPort is empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: "My-Custom-PortForwardDoc",
+			TargetHost:  "db.internal",
+		}
+
+		in := CreateSessionInput(cfg)
+		assertPortForwardParams(t, in.Parameters, "", "db.internal")
+	})
+
+	t.Run("omits host and port when both are empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: "My-Custom-PortForwardDoc",
+		}
+
+		in := CreateSessionInput(cfg)
+		assertPortForwardParams(t, in.Parameters, "", "")
+	})
+}
+
+func assertPortForwardParams(t *testing.T, params map[string][]string, wantPort, wantHost string) {
+	t.Helper()
+
+	gotLocalPort, ok := params["localPortNumber"]
+	if !ok {
+		t.Errorf("missing parameter %q", "localPortNumber")
+	} else if gotLocalPort[0] != "12345" {
+		t.Errorf("parameter %q = %v, want [%q]", "localPortNumber", gotLocalPort, "12345")
+	}
+
+	gotPort, hasPort := params["portNumber"]
+	switch {
+	case wantPort == "" && hasPort:
+		t.Errorf("portNumber parameter = %v, want omitted", gotPort)
+	case wantPort != "" && !hasPort:
+		t.Errorf("missing parameter %q", "portNumber")
+	case wantPort != "" && gotPort[0] != wantPort:
+		t.Errorf("parameter %q = %v, want [%q]", "portNumber", gotPort, wantPort)
+	}
+
+	gotHost, hasHost := params["host"]
+	switch {
+	case wantHost == "" && hasHost:
+		t.Errorf("host parameter = %v, want omitted", gotHost)
+	case wantHost != "" && !hasHost:
+		t.Errorf("missing parameter %q", "host")
+	case wantHost != "" && gotHost[0] != wantHost:
+		t.Errorf("parameter %q = %v, want [%q]", "host", gotHost, wantHost)
 	}
 }
 

--- a/internal/ssm/session_test.go
+++ b/internal/ssm/session_test.go
@@ -8,24 +8,49 @@ import (
 )
 
 // TestCreateSessionInput verifies the AWS port-forwarding request is assembled
-// from the tunnel config: the document name is fixed and the three parameters
-// map to the configured target port, local port and host.
+// from the tunnel config: the document name defaults or follows SSMDocument,
+// and the three parameters map to the configured target port, local port and host.
 func TestCreateSessionInput(t *testing.T) {
-	cfg := TunnelConfig{
-		LocalPort:   "12345",
-		SSMInstance: "i-0abc123",
-		TargetHost:  "db.internal",
-		TargetPort:  "5432",
-	}
+	t.Run("default document when SSMDocument is empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			TargetHost:  "db.internal",
+			TargetPort:  "5432",
+		}
 
-	in := CreateSessionInput(cfg)
+		in := CreateSessionInput(cfg)
 
-	if in.Target == nil || *in.Target != cfg.SSMInstance {
-		t.Errorf("Target = %v, want %q", in.Target, cfg.SSMInstance)
-	}
-	if in.DocumentName == nil || *in.DocumentName != "AWS-StartPortForwardingSessionToRemoteHost" {
-		t.Errorf("DocumentName = %v, want AWS-StartPortForwardingSessionToRemoteHost", in.DocumentName)
-	}
+		if in.Target == nil || *in.Target != cfg.SSMInstance {
+			t.Errorf("Target = %v, want %q", in.Target, cfg.SSMInstance)
+		}
+		if in.DocumentName == nil || *in.DocumentName != DefaultSSMDocument {
+			t.Errorf("DocumentName = %v, want %q", in.DocumentName, DefaultSSMDocument)
+		}
+
+		assertPortForwardParams(t, in.Parameters)
+	})
+
+	t.Run("custom SSMDocument", func(t *testing.T) {
+		const customDoc = "My-Custom-PortForwardDoc"
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: customDoc,
+			TargetHost:  "db.internal",
+			TargetPort:  "5432",
+		}
+
+		in := CreateSessionInput(cfg)
+		if in.DocumentName == nil || *in.DocumentName != customDoc {
+			t.Errorf("DocumentName = %v, want %q", in.DocumentName, customDoc)
+		}
+		assertPortForwardParams(t, in.Parameters)
+	})
+}
+
+func assertPortForwardParams(t *testing.T, params map[string][]string) {
+	t.Helper()
 
 	wantParams := map[string]string{
 		"portNumber":      "5432",
@@ -33,12 +58,12 @@ func TestCreateSessionInput(t *testing.T) {
 		"host":            "db.internal",
 	}
 	for key, want := range wantParams {
-		got, ok := in.Parameters[key]
+		got, ok := params[key]
 		if !ok {
 			t.Errorf("missing parameter %q", key)
 			continue
 		}
-		if len(got) != 1 || got[0] != want {
+		if got[0] != want {
 			t.Errorf("parameter %q = %v, want [%q]", key, got, want)
 		}
 	}

--- a/internal/ssm/session_test.go
+++ b/internal/ssm/session_test.go
@@ -9,7 +9,7 @@ import (
 
 // TestCreateSessionInput verifies the AWS port-forwarding request is assembled
 // from the tunnel config: the document name defaults or follows SSMDocument,
-// and the three parameters map to the configured target port, local port and host.
+// port/localPort are always set, and host is included only when TargetHost is set.
 func TestCreateSessionInput(t *testing.T) {
 	t.Run("default document when SSMDocument is empty", func(t *testing.T) {
 		cfg := TunnelConfig{
@@ -28,7 +28,7 @@ func TestCreateSessionInput(t *testing.T) {
 			t.Errorf("DocumentName = %v, want %q", in.DocumentName, DefaultSSMDocument)
 		}
 
-		assertPortForwardParams(t, in.Parameters)
+		assertPortForwardParams(t, in.Parameters, "db.internal")
 	})
 
 	t.Run("custom SSMDocument", func(t *testing.T) {
@@ -45,17 +45,28 @@ func TestCreateSessionInput(t *testing.T) {
 		if in.DocumentName == nil || *in.DocumentName != customDoc {
 			t.Errorf("DocumentName = %v, want %q", in.DocumentName, customDoc)
 		}
-		assertPortForwardParams(t, in.Parameters)
+		assertPortForwardParams(t, in.Parameters, "db.internal")
+	})
+
+	t.Run("omits host when TargetHost is empty", func(t *testing.T) {
+		cfg := TunnelConfig{
+			LocalPort:   "12345",
+			SSMInstance: "i-0abc123",
+			SSMDocument: "My-Custom-PortForwardDoc",
+			TargetPort:  "5432",
+		}
+
+		in := CreateSessionInput(cfg)
+		assertPortForwardParams(t, in.Parameters, "")
 	})
 }
 
-func assertPortForwardParams(t *testing.T, params map[string][]string) {
+func assertPortForwardParams(t *testing.T, params map[string][]string, wantHost string) {
 	t.Helper()
 
 	wantParams := map[string]string{
 		"portNumber":      "5432",
 		"localPortNumber": "12345",
-		"host":            "db.internal",
 	}
 	for key, want := range wantParams {
 		got, ok := params[key]
@@ -66,6 +77,16 @@ func assertPortForwardParams(t *testing.T, params map[string][]string) {
 		if got[0] != want {
 			t.Errorf("parameter %q = %v, want [%q]", key, got, want)
 		}
+	}
+
+	gotHost, hasHost := params["host"]
+	switch {
+	case wantHost == "" && hasHost:
+		t.Errorf("host parameter = %v, want omitted", gotHost)
+	case wantHost != "" && !hasHost:
+		t.Errorf("missing parameter %q", "host")
+	case wantHost != "" && gotHost[0] != wantHost:
+		t.Errorf("parameter %q = %v, want [%q]", "host", gotHost, wantHost)
 	}
 }
 

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -47,7 +47,11 @@ func ForkRemoteTunnel(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) 
 	}
 
 	// Open a log file for the tunnel
-	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, cfg.TargetPort))
+	logPort := cfg.TargetPort
+	if logPort == "" {
+		logPort = cfg.LocalPort
+	}
+	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, logPort))
 	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Allow custom SSM Document and optional host

Hi, I just want to propose this PR with the following changes:

- Allow to specify a custom SSM Document to connect to the bastion instance
- Make TargetHost optional (given the case that TargetHost is already specified in a custom SSM Document)

#### This is to cover a security case:

Let's suppose that we want to restrict via IAM to certain users to only use certain SSM Documents to provision databases (custom SSM Document case). Also, these custom SSM Documents have a fixed host, so the user that is using the document can only connect to a specific host. In this case TargetHost should be optional.

-----

In addition, the PR covers:
- Fail when TargetHost is not defined and using the default SSM Document
- Documentation
- Tests

I made sure that test run and code follows the repository guidelines.
I'd really appreciate if these changes can be included in the provider.

Thanks in advance, and sorry for the 2 previous PR's, I was merging the code in my fork but forgot to click my own repo by accident.