### PR TITLE
fix(ssh): replace sshtun with a custom forwarder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/aws/smithy-go v1.27.4
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
-	github.com/rgzr/sshtun v1.2.4
 	github.com/shirou/gopsutil/v4 v4.26.6
 	golang.org/x/crypto v0.54.0
 	k8s.io/apimachinery v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -16,12 +16,8 @@ github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJ
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2 h1:RHK7bS+HQMslb1sZpAokUt+zTVmue0hKSs2C791hhzU=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.7.2/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
-github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
-github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
-github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
@@ -78,8 +74,6 @@ github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gliderlabs/ssh v0.3.8 h1:a4YXD1V7xMF9g5nTkdfnja3Sxy1PVDCj1Zg4Wb8vY6c=
-github.com/gliderlabs/ssh v0.3.8/go.mod h1:xYoytBv1sV0aL3CavoDuJIQNURXkkfPA/wxQ1pL1fAU=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -173,8 +167,6 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
-github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5 h1:Ii+DKncOVM8Cu1Hc+ETb5K+23HdAMvESYE3ZJ5b5cMI=
-github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c/go.mod h1:7rwL4CYBLnjLxUqIJNnCWiEdr3bn6IUYi15bNlnbCCU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -182,8 +174,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
-github.com/rgzr/sshtun v1.2.4 h1:x0yJZYlkyH94Kenpvlx6MrlovWDs6TIHmvcZab6cOm4=
-github.com/rgzr/sshtun v1.2.4/go.mod h1:ryJhP7TNA/oQXyna4UUZgPZK3bXWEECDzIc0Nostbdo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/shirou/gopsutil/v4 v4.26.6 h1:Mzr/npDtQC/xpeEuQKHZt8Zo9CmPvhTj8nkR8w5TLDs=

--- a/internal/provider/data_source_ssh.go
+++ b/internal/provider/data_source_ssh.go
@@ -2,30 +2,12 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os/user"
 
-	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
-
-func validateSSHTarget(targetHost, targetSocket types.String, targetPort types.Int64) error {
-	hasPort := !targetPort.IsNull()
-	hasSocket := !targetSocket.IsNull() && targetSocket.ValueString() != ""
-	switch {
-	case hasPort && hasSocket:
-		return errors.New("`target_port` and `target_socket` are mutually exclusive")
-	case !hasPort && !hasSocket:
-		return errors.New("one of `target_port` or `target_socket` must be set")
-	case hasPort && (targetHost.IsNull() || targetHost.ValueString() == ""):
-		return errors.New("`target_host` is required when `target_port` is set")
-	}
-	return nil
-}
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ datasource.DataSource = &SSHDataSource{}
@@ -36,21 +18,6 @@ func NewSSHDataSource() datasource.DataSource {
 
 // SSHDataSource defines the data source implementation.
 type SSHDataSource struct{}
-
-// SSHDataSourceModel describes the data source data model.
-type SSHDataSourceModel struct {
-	LocalHost        types.String `tfsdk:"local_host"`
-	LocalPort        types.Int64  `tfsdk:"local_port"`
-	SSHHost          types.String `tfsdk:"ssh_host"`
-	SSHKey           types.String `tfsdk:"ssh_key"`
-	SSHKeyPassphrase types.String `tfsdk:"ssh_key_passphrase"`
-	SSHPassword      types.String `tfsdk:"ssh_password"`
-	SSHPort          types.Int64  `tfsdk:"ssh_port"`
-	SSHUser          types.String `tfsdk:"ssh_user"`
-	TargetHost       types.String `tfsdk:"target_host"`
-	TargetPort       types.Int64  `tfsdk:"target_port"`
-	TargetSocket     types.String `tfsdk:"target_socket"`
-}
 
 func (d *SSHDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_ssh"
@@ -117,7 +84,7 @@ func (d *SSHDataSource) Schema(ctx context.Context, req datasource.SchemaRequest
 }
 
 func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
-	var data SSHDataSourceModel
+	var data SSHModel
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -126,51 +93,12 @@ func (d *SSHDataSource) Read(ctx context.Context, req datasource.ReadRequest, re
 		return
 	}
 
-	if err := validateSSHTarget(data.TargetHost, data.TargetSocket, data.TargetPort); err != nil {
-		resp.Diagnostics.AddError("Invalid target configuration", err.Error())
+	cfg, err := sshConfig(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid SSH tunnel configuration", err.Error())
 		return
 	}
-
-	localPort := int(data.LocalPort.ValueInt64())
-	if localPort == 0 {
-		var err error
-		localPort, err = libs.GetFreePort()
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-			return
-		}
-	}
-
-	if data.LocalHost.IsNull() {
-		data.LocalHost = types.StringValue("localhost")
-	}
-	data.LocalPort = types.Int64Value(int64(localPort))
-
-	if data.SSHUser.IsNull() {
-		user, err := user.Current()
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to get current user", fmt.Sprintf("Error: %s", err))
-			return
-		}
-		data.SSHUser = types.StringValue(user.Username)
-	}
-	if data.SSHPort.IsNull() {
-		data.SSHPort = types.Int64Value(22)
-	}
-
-	_, err := ssh.ForkRemoteTunnel(ctx, ssh.TunnelConfig{
-		LocalHost:        data.LocalHost.ValueString(),
-		LocalPort:        localPort,
-		SSHHost:          data.SSHHost.ValueString(),
-		SSHKey:           data.SSHKey.ValueString(),
-		SSHKeyPassphrase: data.SSHKeyPassphrase.ValueString(),
-		SSHPassword:      data.SSHPassword.ValueString(),
-		SSHPort:          int(data.SSHPort.ValueInt64()),
-		SSHUser:          data.SSHUser.ValueString(),
-		TargetHost:       data.TargetHost.ValueString(),
-		TargetPort:       int(data.TargetPort.ValueInt64()),
-		TargetSocket:     data.TargetSocket.ValueString(),
-	})
+	_, err = ssh.ForkRemoteTunnel(ctx, cfg)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to fork tunnel process", fmt.Sprintf("Error: %s", err))
 		return

--- a/internal/provider/ephemeral_ssh.go
+++ b/internal/provider/ephemeral_ssh.go
@@ -3,14 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
-	"os/user"
 	"strconv"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral"
 	"github.com/hashicorp/terraform-plugin-framework/ephemeral/schema"
-	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -20,23 +18,8 @@ func NewSSHEphemeral() ephemeral.EphemeralResource {
 	return &SSHEphemeral{}
 }
 
-// SSHEphemeral defines the data source implementation.
+// SSHEphemeral defines the ephemeral resource implementation.
 type SSHEphemeral struct{}
-
-// SSHEphemeralModel describes the data source data model.
-type SSHEphemeralModel struct {
-	LocalHost        types.String `tfsdk:"local_host"`
-	LocalPort        types.Int64  `tfsdk:"local_port"`
-	SSHHost          types.String `tfsdk:"ssh_host"`
-	SSHKey           types.String `tfsdk:"ssh_key"`
-	SSHKeyPassphrase types.String `tfsdk:"ssh_key_passphrase"`
-	SSHPassword      types.String `tfsdk:"ssh_password"`
-	SSHPort          types.Int64  `tfsdk:"ssh_port"`
-	SSHUser          types.String `tfsdk:"ssh_user"`
-	TargetHost       types.String `tfsdk:"target_host"`
-	TargetPort       types.Int64  `tfsdk:"target_port"`
-	TargetSocket     types.String `tfsdk:"target_socket"`
-}
 
 func (d *SSHEphemeral) Metadata(ctx context.Context, req ephemeral.MetadataRequest, resp *ephemeral.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_ssh"
@@ -103,7 +86,7 @@ func (d *SSHEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRequest, 
 }
 
 func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp *ephemeral.OpenResponse) {
-	var data SSHEphemeralModel
+	var data SSHModel
 
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
@@ -112,51 +95,12 @@ func (d *SSHEphemeral) Open(ctx context.Context, req ephemeral.OpenRequest, resp
 		return
 	}
 
-	if err := validateSSHTarget(data.TargetHost, data.TargetSocket, data.TargetPort); err != nil {
-		resp.Diagnostics.AddError("Invalid target configuration", err.Error())
+	cfg, err := sshConfig(&data)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid SSH tunnel configuration", err.Error())
 		return
 	}
-
-	localPort := int(data.LocalPort.ValueInt64())
-	if localPort == 0 {
-		var err error
-		localPort, err = libs.GetFreePort()
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to find open port", fmt.Sprintf("Error: %s", err))
-			return
-		}
-	}
-
-	if data.LocalHost.IsNull() {
-		data.LocalHost = types.StringValue("localhost")
-	}
-	data.LocalPort = types.Int64Value(int64(localPort))
-
-	if data.SSHUser.IsNull() {
-		user, err := user.Current()
-		if err != nil {
-			resp.Diagnostics.AddError("Failed to get current user", fmt.Sprintf("Error: %s", err))
-			return
-		}
-		data.SSHUser = types.StringValue(user.Username)
-	}
-	if data.SSHPort.IsNull() {
-		data.SSHPort = types.Int64Value(22)
-	}
-
-	cmd, err := ssh.ForkRemoteTunnel(ctx, ssh.TunnelConfig{
-		LocalHost:        data.LocalHost.ValueString(),
-		LocalPort:        localPort,
-		SSHHost:          data.SSHHost.ValueString(),
-		SSHKey:           data.SSHKey.ValueString(),
-		SSHKeyPassphrase: data.SSHKeyPassphrase.ValueString(),
-		SSHPassword:      data.SSHPassword.ValueString(),
-		SSHPort:          int(data.SSHPort.ValueInt64()),
-		SSHUser:          data.SSHUser.ValueString(),
-		TargetHost:       data.TargetHost.ValueString(),
-		TargetPort:       int(data.TargetPort.ValueInt64()),
-		TargetSocket:     data.TargetSocket.ValueString(),
-	})
+	cmd, err := ssh.ForkRemoteTunnel(ctx, cfg)
 	if err != nil {
 		resp.Diagnostics.AddError("Failed to fork tunnel process", fmt.Sprintf("Error: %s", err))
 		return

--- a/internal/provider/ssh.go
+++ b/internal/provider/ssh.go
@@ -1,0 +1,83 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"os/user"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type SSHModel struct {
+	LocalHost        types.String `tfsdk:"local_host"`
+	LocalPort        types.Int64  `tfsdk:"local_port"`
+	SSHHost          types.String `tfsdk:"ssh_host"`
+	SSHKey           types.String `tfsdk:"ssh_key"`
+	SSHKeyPassphrase types.String `tfsdk:"ssh_key_passphrase"`
+	SSHPassword      types.String `tfsdk:"ssh_password"`
+	SSHPort          types.Int64  `tfsdk:"ssh_port"`
+	SSHUser          types.String `tfsdk:"ssh_user"`
+	TargetHost       types.String `tfsdk:"target_host"`
+	TargetPort       types.Int64  `tfsdk:"target_port"`
+	TargetSocket     types.String `tfsdk:"target_socket"`
+}
+
+func validateSSHTarget(targetHost, targetSocket types.String, targetPort types.Int64) error {
+	hasPort := !targetPort.IsNull()
+	hasSocket := !targetSocket.IsNull() && targetSocket.ValueString() != ""
+	switch {
+	case hasPort && hasSocket:
+		return errors.New("`target_port` and `target_socket` are mutually exclusive")
+	case !hasPort && !hasSocket:
+		return errors.New("one of `target_port` or `target_socket` must be set")
+	case hasPort && (targetHost.IsNull() || targetHost.ValueString() == ""):
+		return errors.New("`target_host` is required when `target_port` is set")
+	}
+	return nil
+}
+
+func sshConfig(data *SSHModel) (ssh.TunnelConfig, error) {
+	if err := validateSSHTarget(data.TargetHost, data.TargetSocket, data.TargetPort); err != nil {
+		return ssh.TunnelConfig{}, err
+	}
+
+	localPort := int(data.LocalPort.ValueInt64())
+	if localPort == 0 {
+		var err error
+		localPort, err = libs.GetFreePort()
+		if err != nil {
+			return ssh.TunnelConfig{}, fmt.Errorf("find open local port: %w", err)
+		}
+		data.LocalPort = types.Int64Value(int64(localPort))
+	}
+
+	if data.LocalHost.IsNull() || data.LocalHost.ValueString() == "" {
+		data.LocalHost = types.StringValue("localhost")
+	}
+	if data.SSHUser.IsNull() {
+		currentUser, err := user.Current()
+		if err != nil {
+			return ssh.TunnelConfig{}, fmt.Errorf("get current user: %w", err)
+		}
+		data.SSHUser = types.StringValue(currentUser.Username)
+	}
+	if data.SSHPort.IsNull() {
+		data.SSHPort = types.Int64Value(22)
+	}
+
+	return ssh.TunnelConfig{
+		LocalHost:        data.LocalHost.ValueString(),
+		LocalPort:        localPort,
+		SSHHost:          data.SSHHost.ValueString(),
+		SSHKey:           data.SSHKey.ValueString(),
+		SSHKeyPassphrase: data.SSHKeyPassphrase.ValueString(),
+		SSHPassword:      data.SSHPassword.ValueString(),
+		SSHPort:          int(data.SSHPort.ValueInt64()),
+		SSHUser:          data.SSHUser.ValueString(),
+		TargetHost:       data.TargetHost.ValueString(),
+		TargetPort:       int(data.TargetPort.ValueInt64()),
+		TargetSocket:     data.TargetSocket.ValueString(),
+	}, nil
+}

--- a/internal/provider/ssh_test.go
+++ b/internal/provider/ssh_test.go
@@ -1,13 +1,14 @@
 package provider
 
 import (
+	"os/user"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// TestValidateSSHTarget exercises every branch of the target validation: the
+// TestValidateSSHTarget exercises every branch of SSH target validation: the
 // two valid shapes (host+port, socket) and the three rejected ones (both set,
 // neither set, port without a host).
 func TestValidateSSHTarget(t *testing.T) {
@@ -79,5 +80,42 @@ func TestValidateSSHTarget(t *testing.T) {
 				t.Fatalf("error %q does not contain %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestSSHConfigDefaults(t *testing.T) {
+	currentUser, err := user.Current()
+	if err != nil {
+		t.Fatal(err)
+	}
+	data := SSHModel{
+		LocalHost:    types.StringNull(),
+		LocalPort:    types.Int64Value(15432),
+		SSHHost:      types.StringValue("bastion.internal"),
+		SSHPort:      types.Int64Null(),
+		SSHUser:      types.StringNull(),
+		TargetHost:   types.StringValue("db.internal"),
+		TargetPort:   types.Int64Value(5432),
+		TargetSocket: types.StringNull(),
+	}
+
+	cfg, err := sshConfig(&data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.LocalHost != "localhost" || cfg.LocalPort != 15432 {
+		t.Fatalf("local endpoint = %s:%d, want localhost:15432", cfg.LocalHost, cfg.LocalPort)
+	}
+	if cfg.SSHHost != "bastion.internal" || cfg.SSHPort != 22 || cfg.SSHUser != currentUser.Username {
+		t.Fatalf("SSH endpoint defaults not applied: %+v", cfg)
+	}
+	if cfg.TargetHost != "db.internal" || cfg.TargetPort != 5432 || cfg.TargetSocket != "" {
+		t.Fatalf("target not mapped: %+v", cfg)
+	}
+	if data.LocalHost.ValueString() != cfg.LocalHost ||
+		data.LocalPort.ValueInt64() != int64(cfg.LocalPort) ||
+		data.SSHPort.ValueInt64() != int64(cfg.SSHPort) ||
+		data.SSHUser.ValueString() != cfg.SSHUser {
+		t.Fatalf("model not updated: %+v", data)
 	}
 }

--- a/internal/ssh/auth.go
+++ b/internal/ssh/auth.go
@@ -1,0 +1,139 @@
+package ssh
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+const (
+	defaultSSHPort = 22
+	defaultSSHUser = "root"
+	dialTimeout    = 15 * time.Second
+)
+
+// Used when no credentials are configured.
+var defaultKeyNames = []string{"id_rsa", "id_ecdsa", "id_ecdsa_sk", "id_ed25519", "id_ed25519_sk"}
+
+func clientConfig(cfg TunnelConfig) (*ssh.ClientConfig, error) {
+	methods, err := authMethods(cfg)
+	if err != nil {
+		return nil, err
+	}
+	sshUser := cfg.SSHUser
+	if sshUser == "" {
+		sshUser = defaultSSHUser
+	}
+	return &ssh.ClientConfig{
+		User: sshUser,
+		Auth: methods,
+		// Preserve existing behavior for newly-created bastions with unknown keys.
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         dialTimeout,
+	}, nil
+}
+
+func authMethods(cfg TunnelConfig) ([]ssh.AuthMethod, error) {
+	var methods []ssh.AuthMethod
+	if cfg.SSHKey != "" {
+		signer, err := parseConfiguredKey(cfg.SSHKey, cfg.SSHKeyPassphrase)
+		if err != nil {
+			return nil, err
+		}
+		methods = append(methods, ssh.PublicKeys(signer))
+	}
+	if cfg.SSHPassword != "" {
+		methods = append(methods, ssh.Password(cfg.SSHPassword))
+	}
+	if len(methods) > 0 {
+		return methods, nil
+	}
+
+	if keys := defaultKeys(); keys != nil {
+		methods = append(methods, keys)
+	}
+	if keys := agentKeys(); keys != nil {
+		methods = append(methods, keys)
+	}
+	if len(methods) == 0 {
+		return nil, errors.New("no SSH credentials: set ssh_key or ssh_password, " +
+			"keep a key in ~/.ssh, or run an ssh-agent")
+	}
+	return methods, nil
+}
+
+// ssh_key accepts either inline PEM or a file path.
+func parseConfiguredKey(key, passphrase string) (ssh.Signer, error) {
+	pemBytes := []byte(key)
+	if _, statErr := os.Stat(key); statErr == nil {
+		read, err := os.ReadFile(key)
+		if err != nil {
+			return nil, fmt.Errorf("read SSH key file %s: %w", key, err)
+		}
+		pemBytes = read
+	}
+	if passphrase != "" {
+		signer, err := ssh.ParsePrivateKeyWithPassphrase(pemBytes, []byte(passphrase))
+		if err != nil {
+			return nil, fmt.Errorf("parse encrypted SSH key: %w", err)
+		}
+		return signer, nil
+	}
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse SSH key: %w", err)
+	}
+	return signer, nil
+}
+
+// Ignore unusable default keys because they are implicit candidates.
+func defaultKeys() ssh.AuthMethod {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = "/root"
+	}
+	var signers []ssh.Signer
+	for _, name := range defaultKeyNames {
+		pemBytes, err := os.ReadFile(filepath.Join(home, ".ssh", name))
+		if err != nil {
+			continue
+		}
+		signer, err := ssh.ParsePrivateKey(pemBytes)
+		if err != nil {
+			continue
+		}
+		signers = append(signers, signer)
+	}
+	if len(signers) == 0 {
+		return nil
+	}
+	return ssh.PublicKeys(signers...)
+}
+
+// Probe now, but reconnect for each callback to avoid holding the agent socket.
+func agentKeys() ssh.AuthMethod {
+	socket := os.Getenv("SSH_AUTH_SOCK")
+	if socket == "" {
+		return nil
+	}
+	probe, err := net.Dial("unix", socket)
+	if err != nil {
+		return nil
+	}
+	_ = probe.Close()
+
+	return ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
+		conn, err := net.Dial("unix", socket)
+		if err != nil {
+			return nil, err
+		}
+		defer conn.Close()
+		return agent.NewClient(conn).Signers()
+	})
+}

--- a/internal/ssh/auth.go
+++ b/internal/ssh/auth.go
@@ -1,8 +1,10 @@
 package ssh
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -116,7 +118,7 @@ func defaultKeys() ssh.AuthMethod {
 	return ssh.PublicKeys(signers...)
 }
 
-// Probe now, but reconnect for each callback to avoid holding the agent socket.
+// Probe now, but reconnect for each agent request to avoid holding the socket.
 func agentKeys() ssh.AuthMethod {
 	socket := os.Getenv("SSH_AUTH_SOCK")
 	if socket == "" {
@@ -134,6 +136,56 @@ func agentKeys() ssh.AuthMethod {
 			return nil, err
 		}
 		defer conn.Close()
-		return agent.NewClient(conn).Signers()
+		keys, err := agent.NewClient(conn).List()
+		if err != nil {
+			return nil, err
+		}
+		signers := make([]ssh.Signer, 0, len(keys))
+		for _, key := range keys {
+			signers = append(signers, &agentSigner{socket: socket, pub: key})
+		}
+		return signers, nil
 	})
+}
+
+// agentSigner dials the agent per signature. agent.Client.Signers() would bind
+// its signers to one connection, and ssh uses the signers a PublicKeysCallback
+// returned after the callback has returned, so that connection is closed by the
+// time the handshake asks for a signature.
+type agentSigner struct {
+	socket string
+	pub    ssh.PublicKey
+}
+
+var _ ssh.AlgorithmSigner = (*agentSigner)(nil)
+
+func (s *agentSigner) PublicKey() ssh.PublicKey { return s.pub }
+
+func (s *agentSigner) Sign(rand io.Reader, data []byte) (*ssh.Signature, error) {
+	return s.SignWithAlgorithm(rand, data, "")
+}
+
+func (s *agentSigner) SignWithAlgorithm(rand io.Reader, data []byte, algorithm string) (*ssh.Signature, error) {
+	conn, err := net.Dial("unix", s.socket)
+	if err != nil {
+		return nil, fmt.Errorf("connect to ssh-agent: %w", err)
+	}
+	defer conn.Close()
+
+	// Delegate rather than sign through the agent client directly, to keep its
+	// mapping from signature algorithm to agent flags.
+	signers, err := agent.NewClient(conn).Signers()
+	if err != nil {
+		return nil, err
+	}
+	for _, signer := range signers {
+		if !bytes.Equal(signer.PublicKey().Marshal(), s.pub.Marshal()) {
+			continue
+		}
+		if as, ok := signer.(ssh.AlgorithmSigner); ok {
+			return as.SignWithAlgorithm(rand, data, algorithm)
+		}
+		return signer.Sign(rand, data)
+	}
+	return nil, fmt.Errorf("ssh-agent dropped the %s key it offered", s.pub.Type())
 }

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -1,0 +1,179 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// isolateCredentials empties the ambient sources authMethods falls back to, so a
+// test never picks up the developer's own keys or agent.
+func isolateCredentials(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+	t.Setenv("SSH_AUTH_SOCK", "")
+	return home
+}
+
+// generateKey returns a PEM-encoded ed25519 private key, encrypted when a
+// passphrase is given.
+func generateKey(t *testing.T, passphrase string) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var block *pem.Block
+	if passphrase == "" {
+		block, err = ssh.MarshalPrivateKey(priv, "")
+	} else {
+		block, err = ssh.MarshalPrivateKeyWithPassphrase(priv, "", []byte(passphrase))
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(pem.EncodeToMemory(block))
+}
+
+func writeKeyFile(t *testing.T, dir, name, keyPEM string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(keyPEM), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestAuthMethodsAcceptsKeyInlineOrByPath covers the ssh_key contract inherited
+// from the previous implementation: the attribute holds either PEM content or the
+// path of a file holding it, and an existing file at that path is what decides.
+func TestAuthMethodsAcceptsKeyInlineOrByPath(t *testing.T) {
+	dir := isolateCredentials(t)
+	plain := generateKey(t, "")
+	encrypted := generateKey(t, "s3cret")
+
+	tests := []struct {
+		name string
+		cfg  TunnelConfig
+	}{
+		{name: "inline key", cfg: TunnelConfig{SSHKey: plain}},
+		{name: "key file", cfg: TunnelConfig{SSHKey: writeKeyFile(t, dir, "plain.pem", plain)}},
+		{
+			name: "inline encrypted key",
+			cfg:  TunnelConfig{SSHKey: encrypted, SSHKeyPassphrase: "s3cret"},
+		},
+		{
+			name: "encrypted key file",
+			cfg: TunnelConfig{
+				SSHKey:           writeKeyFile(t, dir, "encrypted.pem", encrypted),
+				SSHKeyPassphrase: "s3cret",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			methods, err := authMethods(tt.cfg)
+			if err != nil {
+				t.Fatalf("authMethods() = %v", err)
+			}
+			if len(methods) != 1 {
+				t.Fatalf("methods = %d, want 1 (public key)", len(methods))
+			}
+		})
+	}
+}
+
+func TestAuthMethodsRejectsUnusableKey(t *testing.T) {
+	isolateCredentials(t)
+	tests := []struct {
+		name    string
+		cfg     TunnelConfig
+		wantErr string
+	}{
+		{
+			name:    "not a key",
+			cfg:     TunnelConfig{SSHKey: "definitely not a PEM block"},
+			wantErr: "parse SSH key",
+		},
+		{
+			name:    "wrong passphrase",
+			cfg:     TunnelConfig{SSHKey: generateKey(t, "s3cret"), SSHKeyPassphrase: "wrong"},
+			wantErr: "parse encrypted SSH key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := authMethods(tt.cfg)
+			if err == nil {
+				t.Fatal("authMethods() = nil, want an error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want it to contain %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestAuthMethodsOffersKeyAndPassword documents a deliberate widening: sshtun
+// used whichever credential was set last, while a bastion may now be offered
+// both.
+func TestAuthMethodsOffersKeyAndPassword(t *testing.T) {
+	isolateCredentials(t)
+	methods, err := authMethods(TunnelConfig{SSHKey: generateKey(t, ""), SSHPassword: "hunter2"})
+	if err != nil {
+		t.Fatalf("authMethods() = %v", err)
+	}
+	if len(methods) != 2 {
+		t.Fatalf("methods = %d, want 2 (public key, password)", len(methods))
+	}
+}
+
+// TestAuthMethodsFallsBackToHomeDirectoryKeys keeps the implicit behaviour
+// sshtun's automatic mode gave configurations that set no credentials at all.
+func TestAuthMethodsFallsBackToHomeDirectoryKeys(t *testing.T) {
+	home := isolateCredentials(t)
+	if err := os.Mkdir(filepath.Join(home, ".ssh"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	writeKeyFile(t, filepath.Join(home, ".ssh"), "id_ed25519", generateKey(t, ""))
+
+	methods, err := authMethods(TunnelConfig{})
+	if err != nil {
+		t.Fatalf("authMethods() = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Fatalf("methods = %d, want 1 (keys from ~/.ssh)", len(methods))
+	}
+}
+
+func TestAuthMethodsWithoutAnyCredential(t *testing.T) {
+	isolateCredentials(t)
+	if _, err := authMethods(TunnelConfig{}); err == nil {
+		t.Fatal("authMethods() = nil, want an error naming the ways to authenticate")
+	}
+}
+
+func TestClientConfigDefaultsToRoot(t *testing.T) {
+	isolateCredentials(t)
+	cfg, err := clientConfig(TunnelConfig{SSHKey: generateKey(t, "")})
+	if err != nil {
+		t.Fatalf("clientConfig() = %v", err)
+	}
+	if cfg.User != defaultSSHUser {
+		t.Errorf("User = %q, want %q", cfg.User, defaultSSHUser)
+	}
+	if cfg.Timeout != dialTimeout {
+		t.Errorf("Timeout = %v, want %v", cfg.Timeout, dialTimeout)
+	}
+	if cfg.HostKeyCallback == nil {
+		t.Error("HostKeyCallback is nil, which makes every handshake fail")
+	}
+}

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -1,15 +1,20 @@
 package ssh
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/pem"
+	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
 )
 
 // isolateCredentials empties the ambient sources authMethods falls back to, so a
@@ -159,6 +164,56 @@ func TestAuthMethodsWithoutAnyCredential(t *testing.T) {
 	if _, err := authMethods(TunnelConfig{}); err == nil {
 		t.Fatal("authMethods() = nil, want an error naming the ways to authenticate")
 	}
+}
+
+// startAgent serves an in-process ssh-agent holding keyPEM and points
+// SSH_AUTH_SOCK at it.
+func startAgent(t *testing.T, keyPEM string) {
+	t.Helper()
+	key, err := ssh.ParseRawPrivateKey([]byte(keyPEM))
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyring := agent.NewKeyring()
+	if err := keyring.Add(agent.AddedKey{PrivateKey: key}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Not t.TempDir(): its path can exceed the unix socket path length limit.
+	dir, err := os.MkdirTemp("", "agt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	listener, err := net.Listen("unix", filepath.Join(dir, "s"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	go acceptLoop(listener, func(conn net.Conn) { _ = agent.ServeAgent(keyring, conn) })
+	t.Setenv("SSH_AUTH_SOCK", listener.Addr().String())
+}
+
+// TestAuthMethodsSignsWithAgentKey guards the agent path end to end: ssh asks the
+// signers a PublicKeysCallback returned for a signature only after the callback
+// has returned, so a signer bound to a connection the callback closed fails the
+// handshake.
+func TestAuthMethodsSignsWithAgentKey(t *testing.T) {
+	isolateCredentials(t)
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	startAgent(t, keyPEM)
+	sshAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(sshtest.StartServer(t, authorizedKey)))
+
+	cfg, err := clientConfig(TunnelConfig{SSHUser: sshtest.User})
+	if err != nil {
+		t.Fatalf("clientConfig() = %v", err)
+	}
+	client, err := dialSSH(context.Background(), sshAddr, cfg)
+	if err != nil {
+		t.Fatalf("dialSSH() = %v", err)
+	}
+	_ = client.Close()
 }
 
 func TestClientConfigDefaultsToRoot(t *testing.T) {

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -1,0 +1,145 @@
+package ssh
+
+import (
+	"context"
+	"log"
+	"net"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// Keep the connection ahead of Azure's idle timeout.
+const keepaliveInterval = 30 * time.Second
+
+// dialSSH uses one context for the TCP connection and SSH handshake.
+func dialSSH(ctx context.Context, addr string, cfg *ssh.ClientConfig) (*ssh.Client, error) {
+	connectCtx := ctx
+	cancel := func() {}
+	if cfg.Timeout > 0 {
+		connectCtx, cancel = context.WithTimeout(ctx, cfg.Timeout)
+	}
+	defer cancel()
+
+	conn, err := (&net.Dialer{}).DialContext(connectCtx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// NewClientConn has no context support; closing the transport unblocks it.
+	closeDone := make(chan struct{})
+	stopClose := context.AfterFunc(connectCtx, func() {
+		_ = conn.Close()
+		close(closeDone)
+	})
+	sshConn, chans, reqs, err := ssh.NewClientConn(conn, addr, cfg)
+	if !stopClose() {
+		<-closeDone
+	}
+	if ctxErr := connectCtx.Err(); ctxErr != nil {
+		_ = conn.Close()
+		return nil, ctxErr
+	}
+	if err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return ssh.NewClient(sshConn, chans, reqs), nil
+}
+
+// clientPool multiplexes forwarded channels over one SSH connection.
+type clientPool struct {
+	dial func(context.Context) (*ssh.Client, error)
+
+	mu       sync.Mutex
+	client   *ssh.Client
+	inflight *handshake
+	closed   bool
+}
+
+type handshake struct {
+	done   chan struct{}
+	client *ssh.Client
+	err    error
+}
+
+// Concurrent callers share one in-flight handshake.
+func (p *clientPool) get(ctx context.Context) (*ssh.Client, error) {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil, net.ErrClosed
+	}
+	if p.client != nil {
+		client := p.client
+		p.mu.Unlock()
+		return client, nil
+	}
+	if attempt := p.inflight; attempt != nil {
+		p.mu.Unlock()
+		select {
+		case <-attempt.done:
+			return attempt.client, attempt.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	attempt := &handshake{done: make(chan struct{})}
+	p.inflight = attempt
+	p.mu.Unlock()
+
+	client, err := p.dial(ctx)
+
+	p.mu.Lock()
+	p.inflight = nil
+	if err == nil {
+		if p.closed {
+			_ = client.Close()
+			client, err = nil, net.ErrClosed
+		} else {
+			p.client = client
+			go p.tend(client)
+		}
+	}
+	p.mu.Unlock()
+
+	attempt.client, attempt.err = client, err
+	close(attempt.done)
+	return client, err
+}
+
+func (p *clientPool) tend(client *ssh.Client) {
+	go keepalive(client)
+	log.Printf("ssh connection ended: %v", client.Wait())
+	p.discard(client)
+}
+
+func keepalive(client *ssh.Client) {
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		if _, _, err := client.SendRequest("keepalive@openssh.com", true, nil); err != nil {
+			return
+		}
+	}
+}
+
+func (p *clientPool) discard(client *ssh.Client) {
+	p.mu.Lock()
+	if p.client == client {
+		p.client = nil
+	}
+	p.mu.Unlock()
+	_ = client.Close()
+}
+
+func (p *clientPool) close() {
+	p.mu.Lock()
+	client := p.client
+	p.client, p.closed = nil, true
+	p.mu.Unlock()
+	if client != nil {
+		_ = client.Close()
+	}
+}

--- a/internal/ssh/client_test.go
+++ b/internal/ssh/client_test.go
@@ -1,0 +1,84 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// startStalledSSHPeer leaves NewClientConn blocked in version exchange.
+func startStalledSSHPeer(t *testing.T) (string, <-chan struct{}) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan struct{})
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		close(accepted)
+		defer conn.Close()
+		_, _ = io.Copy(io.Discard, conn)
+	}()
+	return listener.Addr().String(), accepted
+}
+
+func TestDialSSHBoundsHandshake(t *testing.T) {
+	addr, accepted := startStalledSSHPeer(t)
+	cfg := &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         200 * time.Millisecond,
+	}
+
+	_, err := dialSSH(context.Background(), addr, cfg)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("dialSSH() error = %v, want context deadline exceeded", err)
+	}
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("SSH peer never accepted the TCP connection")
+	}
+}
+
+func TestDialSSHCancelsHandshake(t *testing.T) {
+	addr, accepted := startStalledSSHPeer(t)
+	cfg := &ssh.ClientConfig{
+		User:            "test",
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         10 * time.Second,
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := dialSSH(ctx, addr, cfg)
+		result <- err
+	}()
+
+	select {
+	case <-accepted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("SSH peer never accepted the TCP connection")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("dialSSH() error = %v, want context canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("dialSSH did not stop after context cancellation")
+	}
+}

--- a/internal/ssh/fixtures_test.go
+++ b/internal/ssh/fixtures_test.go
@@ -1,0 +1,102 @@
+package ssh
+
+import (
+	"context"
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
+	"golang.org/x/crypto/ssh"
+)
+
+// tunnel is a forwarder running against the in-process bastion, plus the handshake
+// counter that proves how many SSH connections it needed.
+type tunnel struct {
+	addr       string
+	handshakes *atomic.Int32
+	clients    *clientPool
+}
+
+// startTunnel forwards a local port to target through a fresh in-process bastion,
+// serving until the test ends.
+func startTunnel(t *testing.T, network, target string) *tunnel {
+	t.Helper()
+
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	sshAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(sshtest.StartServer(t, authorizedKey)))
+	clientCfg, err := clientConfig(TunnelConfig{SSHUser: sshtest.User, SSHKey: keyPEM})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var handshakes atomic.Int32
+	clients := &clientPool{dial: func(ctx context.Context) (*ssh.Client, error) {
+		handshakes.Add(1)
+		return dialSSH(ctx, sshAddr, clientCfg)
+	}}
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	fwd := newForwarder(listener, clients, network, target)
+	served := make(chan error, 1)
+	go func() { served <- fwd.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		fwd.Close()
+		clients.close()
+		if err := <-served; err != nil {
+			t.Errorf("serve() = %v", err)
+		}
+	})
+
+	return &tunnel{addr: listener.Addr().String(), handshakes: &handshakes, clients: clients}
+}
+
+func (tun *tunnel) dial(t *testing.T) net.Conn {
+	t.Helper()
+	conn, err := net.Dial("tcp", tun.addr)
+	if err != nil {
+		t.Fatalf("dialing tunnel: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func closeWrite(t *testing.T, conn net.Conn) {
+	t.Helper()
+	if !libs.HalfClose(conn) {
+		t.Fatalf("%T cannot half-close", conn)
+	}
+}
+
+// startTCPTarget serves handle on a random localhost port and returns its
+// address.
+func startTCPTarget(t *testing.T, handle func(net.Conn)) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go acceptLoop(listener, handle)
+	return listener.Addr().String()
+}
+
+func acceptLoop(listener net.Listener, handle func(net.Conn)) {
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			return // listener closed with the test
+		}
+		go func() {
+			defer conn.Close()
+			handle(conn)
+		}()
+	}
+}

--- a/internal/ssh/forward.go
+++ b/internal/ssh/forward.go
@@ -14,11 +14,21 @@ type forwarder struct {
 	clients *clientPool
 	network string
 	target  string
+	server  *libs.ConnServer
 }
 
-func newForwarder(listener net.Listener, clients *clientPool, network, target string) *libs.ConnServer {
+func newForwarder(listener net.Listener, clients *clientPool, network, target string) *forwarder {
 	f := &forwarder{clients: clients, network: network, target: target}
-	return libs.NewConnServer(listener, f.handle)
+	f.server = libs.NewConnServer(listener, f.handle)
+	return f
+}
+
+func (f *forwarder) Serve(ctx context.Context) error {
+	return f.server.Serve(ctx)
+}
+
+func (f *forwarder) Close() {
+	f.server.Close()
 }
 
 func (f *forwarder) handle(ctx context.Context, local net.Conn) {
@@ -39,7 +49,7 @@ func (f *forwarder) dialTarget(ctx context.Context) (net.Conn, error) {
 		if err != nil {
 			return nil, err
 		}
-		remote, err := client.Dial(f.network, f.target)
+		remote, err := client.DialContext(ctx, f.network, f.target)
 		if err == nil {
 			return remote, nil
 		}

--- a/internal/ssh/forward.go
+++ b/internal/ssh/forward.go
@@ -1,0 +1,54 @@
+package ssh
+
+import (
+	"context"
+	"errors"
+	"log"
+	"net"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"golang.org/x/crypto/ssh"
+)
+
+type forwarder struct {
+	clients *clientPool
+	network string
+	target  string
+}
+
+func newForwarder(listener net.Listener, clients *clientPool, network, target string) *libs.ConnServer {
+	f := &forwarder{clients: clients, network: network, target: target}
+	return libs.NewConnServer(listener, f.handle)
+}
+
+func (f *forwarder) handle(ctx context.Context, local net.Conn) {
+	remote, err := f.dialTarget(ctx)
+	if err != nil {
+		// A target may come up later without requiring a new tunnel.
+		log.Printf("forward to %s failed: %v", f.target, err)
+		return
+	}
+	libs.Relay(local, remote)
+}
+
+// Retry transport failures once; target rejections leave the SSH client usable.
+func (f *forwarder) dialTarget(ctx context.Context) (net.Conn, error) {
+	var lastErr error
+	for range 2 {
+		client, err := f.clients.get(ctx)
+		if err != nil {
+			return nil, err
+		}
+		remote, err := client.Dial(f.network, f.target)
+		if err == nil {
+			return remote, nil
+		}
+		var openErr *ssh.OpenChannelError
+		if errors.As(err, &openErr) {
+			return nil, err
+		}
+		f.clients.discard(client)
+		lastErr = err
+	}
+	return nil, lastErr
+}

--- a/internal/ssh/forward_test.go
+++ b/internal/ssh/forward_test.go
@@ -1,0 +1,269 @@
+package ssh
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+)
+
+// TestForwardPassesHalfCloseThrough is the regression test for the bug that
+// replaced rgzr/sshtun: a client that finished sending (CloseWrite) must still
+// receive the reply the target writes afterwards. Tearing the connection down on
+// the first EOF instead — what sshtun did — loses that reply, which is how a
+// keep-alive connection closed by a Kubernetes API server killed an in-flight
+// POST with "unexpected EOF".
+func TestForwardPassesHalfCloseThrough(t *testing.T) {
+	target := startTCPTarget(t, func(conn net.Conn) {
+		request, err := io.ReadAll(conn)
+		if err != nil {
+			t.Errorf("target reading request: %v", err)
+			return
+		}
+		if _, err := conn.Write(append([]byte("reply to "), request...)); err != nil {
+			t.Errorf("target writing reply: %v", err)
+		}
+	})
+	tun := startTunnel(t, "tcp", target)
+
+	conn := tun.dial(t)
+	if _, err := conn.Write([]byte("request")); err != nil {
+		t.Fatalf("writing request: %v", err)
+	}
+	closeWrite(t, conn)
+
+	reply, err := io.ReadAll(conn)
+	if err != nil {
+		t.Fatalf("reading reply after half-close: %v", err)
+	}
+	if string(reply) != "reply to request" {
+		t.Fatalf("reply = %q, want %q", reply, "reply to request")
+	}
+}
+
+// TestForwardDeliversWholeResponseWhenTargetCloses covers the mirror image: the
+// target closing must reach the client as a clean EOF after every byte it sent,
+// not as a truncated stream.
+func TestForwardDeliversWholeResponseWhenTargetCloses(t *testing.T) {
+	payload := bytes.Repeat([]byte("0123456789abcdef"), 64*1024) // 1 MiB
+	target := startTCPTarget(t, func(conn net.Conn) {
+		if _, err := conn.Write(payload); err != nil {
+			t.Errorf("target writing payload: %v", err)
+		}
+	})
+	tun := startTunnel(t, "tcp", target)
+
+	got, err := io.ReadAll(tun.dial(t))
+	if err != nil {
+		t.Fatalf("reading payload: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("read %d bytes, want %d", len(got), len(payload))
+	}
+}
+
+// TestForwardReusesOneSSHConnection pins the second half of the fix: every
+// forwarded connection is a channel on one SSH connection. sshtun re-dialed
+// whenever the connection count returned to zero, and those repeated handshakes
+// are what tripped the bastion's MaxStartups throttle.
+func TestForwardReusesOneSSHConnection(t *testing.T) {
+	tun := startTunnel(t, "tcp", startTCPTarget(t, echoUntilEOF))
+
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			conn, err := net.Dial("tcp", tun.addr)
+			if err != nil {
+				t.Errorf("dialing tunnel: %v", err)
+				return
+			}
+			defer conn.Close()
+			assertEcho(t, conn, []byte(strings.Repeat("x", i+1)))
+		}()
+	}
+	wg.Wait()
+
+	// Sequential connections too: a pool that closed on idle would re-dial here.
+	for range 3 {
+		conn := tun.dial(t)
+		assertEcho(t, conn, []byte("sequential"))
+		_ = conn.Close()
+	}
+
+	if got := tun.handshakes.Load(); got != 1 {
+		t.Fatalf("SSH handshakes = %d, want 1", got)
+	}
+}
+
+// TestForwardRedialsAfterConnectionLoss covers a bastion that drops the SSH
+// connection mid-run: the listener must recover instead of failing every later
+// connection on a dead handle.
+func TestForwardRedialsAfterConnectionLoss(t *testing.T) {
+	tun := startTunnel(t, "tcp", startTCPTarget(t, echoUntilEOF))
+
+	first := tun.dial(t)
+	assertEcho(t, first, []byte("before"))
+	_ = first.Close()
+
+	client, err := tun.clients.get(context.Background())
+	if err != nil {
+		t.Fatalf("get client: %v", err)
+	}
+	if err := client.Close(); err != nil {
+		t.Fatalf("closing SSH connection: %v", err)
+	}
+
+	assertEcho(t, tun.dial(t), []byte("after"))
+	if got := tun.handshakes.Load(); got != 2 {
+		t.Fatalf("SSH handshakes = %d, want 2", got)
+	}
+}
+
+// TestForwardKeepsSSHConnectionWhenTargetRefuses guards the retry in dialTarget:
+// a refused target is the bastion answering, so the SSH connection stays and no
+// second handshake happens.
+func TestForwardKeepsSSHConnectionWhenTargetRefuses(t *testing.T) {
+	closed, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refused := closed.Addr().String()
+	if err := closed.Close(); err != nil {
+		t.Fatal(err)
+	}
+	tun := startTunnel(t, "tcp", refused)
+
+	conn := tun.dial(t)
+	if _, err := io.ReadAll(conn); err != nil {
+		t.Fatalf("reading from refused forward: %v", err)
+	}
+	if got := tun.handshakes.Load(); got != 1 {
+		t.Fatalf("SSH handshakes = %d, want 1", got)
+	}
+}
+
+// TestForwardToUnixSocket exercises the target_socket path, which forwards over a
+// direct-streamlocal channel rather than direct-tcpip.
+func TestForwardToUnixSocket(t *testing.T) {
+	socket := filepath.Join(t.TempDir(), "target.sock")
+	listener, err := net.Listen("unix", socket)
+	if err != nil {
+		t.Skipf("unix sockets unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go acceptLoop(listener, echoUntilEOF)
+
+	tun := startTunnel(t, "unix", socket)
+	assertEcho(t, tun.dial(t), []byte("over a socket"))
+}
+
+// TestRemoteConnCanHalfClose pins the assumption relay is built on: the
+// connection x/crypto/ssh hands back for a forwarded channel can half-close. The
+// concrete type is unexported, so this cannot be a compile-time assertion.
+func TestRemoteConnCanHalfClose(t *testing.T) {
+	target := startTCPTarget(t, echoUntilEOF)
+	tun := startTunnel(t, "tcp", target)
+	client, err := tun.clients.get(context.Background())
+	if err != nil {
+		t.Fatalf("get client: %v", err)
+	}
+
+	remote, err := client.Dial("tcp", target)
+	if err != nil {
+		t.Fatalf("dialing through SSH: %v", err)
+	}
+	defer remote.Close()
+	if !libs.HalfClose(remote) {
+		t.Fatalf("%T cannot half-close; relay would fall back to a full close", remote)
+	}
+}
+
+func TestTargetEndpoint(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         TunnelConfig
+		wantNetwork string
+		wantAddress string
+	}{
+		{
+			name:        "tcp target",
+			cfg:         TunnelConfig{TargetHost: "db.internal", TargetPort: 5432},
+			wantNetwork: "tcp",
+			wantAddress: "db.internal:5432",
+		},
+		{
+			name:        "ipv6 target is bracketed",
+			cfg:         TunnelConfig{TargetHost: "::1", TargetPort: 443},
+			wantNetwork: "tcp",
+			wantAddress: "[::1]:443",
+		},
+		{
+			name:        "socket wins over host and port",
+			cfg:         TunnelConfig{TargetHost: "db.internal", TargetPort: 5432, TargetSocket: "/run/app.sock"},
+			wantNetwork: "unix",
+			wantAddress: "/run/app.sock",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			network, address := targetEndpoint(tt.cfg)
+			if network != tt.wantNetwork || address != tt.wantAddress {
+				t.Fatalf("targetEndpoint() = %q, %q; want %q, %q", network, address, tt.wantNetwork, tt.wantAddress)
+			}
+		})
+	}
+}
+
+// TestRunTunnelReportsBadCredentials checks the readiness contract: a tunnel that
+// cannot authenticate must fail instead of binding a listener that fails later.
+func TestRunTunnelReportsBadCredentials(t *testing.T) {
+	// An empty HOME with no agent keeps the default-credential fallback from
+	// finding the developer's own keys.
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	localPort, err := libs.GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = runTunnel(context.Background(), TunnelConfig{
+		SSHHost:   "127.0.0.1",
+		SSHPort:   1,
+		LocalHost: "127.0.0.1",
+		LocalPort: localPort,
+	})
+	if err == nil {
+		t.Fatal("runTunnel() = nil, want an error")
+	}
+	if !strings.Contains(err.Error(), "no SSH credentials") {
+		t.Fatalf("error = %v, want it to name the missing credentials", err)
+	}
+}
+
+func echoUntilEOF(conn net.Conn) {
+	_, _ = io.Copy(conn, conn)
+}
+
+func assertEcho(t *testing.T, conn net.Conn, payload []byte) {
+	t.Helper()
+	if _, err := conn.Write(payload); err != nil {
+		t.Errorf("writing %d bytes: %v", len(payload), err)
+		return
+	}
+	got := make([]byte, len(payload))
+	if _, err := io.ReadFull(conn, got); err != nil {
+		t.Errorf("reading echo: %v", err)
+		return
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("echo = %q, want %q", got, payload)
+	}
+}

--- a/internal/ssh/forward_test.go
+++ b/internal/ssh/forward_test.go
@@ -6,11 +6,15 @@ import (
 	"io"
 	"net"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
+	"golang.org/x/crypto/ssh"
 )
 
 // TestForwardPassesHalfCloseThrough is the regression test for the bug that
@@ -150,6 +154,60 @@ func TestForwardKeepsSSHConnectionWhenTargetRefuses(t *testing.T) {
 	}
 }
 
+// TestForwardCancellationInterruptsTargetDial guards shutdown while a bastion
+// has received a channel-open request but has not accepted or rejected it.
+func TestForwardCancellationInterruptsTargetDial(t *testing.T) {
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	channelOpened := make(chan struct{}, 1)
+	sshPort := sshtest.StartServerWithChannelHandler(t, authorizedKey, func(ssh.NewChannel) {
+		channelOpened <- struct{}{}
+		// Deliberately leave the channel-open request unanswered.
+	})
+	clientCfg, err := clientConfig(TunnelConfig{SSHUser: sshtest.User, SSHKey: keyPEM})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sshAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(sshPort))
+	clients := &clientPool{dial: func(ctx context.Context) (*ssh.Client, error) {
+		return dialSSH(ctx, sshAddr, clientCfg)
+	}}
+	t.Cleanup(clients.close)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	fwd := newForwarder(listener, clients, "tcp", "target.internal:443")
+	served := make(chan error, 1)
+	go func() { served <- fwd.Serve(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		fwd.Close()
+	})
+
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	select {
+	case <-channelOpened:
+	case <-time.After(time.Second):
+		t.Fatal("bastion did not receive the target channel-open request")
+	}
+
+	cancel()
+	select {
+	case err := <-served:
+		if err != nil {
+			t.Fatalf("Serve() = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve() did not return after cancellation")
+	}
+}
+
 // TestForwardToUnixSocket exercises the target_socket path, which forwards over a
 // direct-streamlocal channel rather than direct-tcpip.
 func TestForwardToUnixSocket(t *testing.T) {
@@ -245,6 +303,35 @@ func TestRunTunnelReportsBadCredentials(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no SSH credentials") {
 		t.Fatalf("error = %v, want it to name the missing credentials", err)
+	}
+}
+
+// TestRunTunnelReportsUnreachableTarget preserves the startup contract: ready
+// means both the SSH connection and the configured target have been reached.
+func TestRunTunnelReportsUnreachableTarget(t *testing.T) {
+	keyPEM, authorizedKey := sshtest.GenerateClientKey(t)
+	localPort, err := libs.GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	missingSocket := filepath.Join(t.TempDir(), "missing.sock")
+	err = runTunnel(ctx, TunnelConfig{
+		LocalHost:    "127.0.0.1",
+		LocalPort:    localPort,
+		SSHHost:      "127.0.0.1",
+		SSHKey:       keyPEM,
+		SSHPort:      sshtest.StartServer(t, authorizedKey),
+		SSHUser:      sshtest.User,
+		TargetSocket: missingSocket,
+	})
+	if err == nil {
+		t.Fatal("runTunnel() = nil, want an unreachable-target error")
+	}
+	if !strings.Contains(err.Error(), "connect to SSH target "+missingSocket) {
+		t.Fatalf("error = %v, want it to identify the unreachable target", err)
 	}
 }
 

--- a/internal/ssh/sshtest/server.go
+++ b/internal/ssh/sshtest/server.go
@@ -57,6 +57,17 @@ func GenerateClientKey(t testing.TB) (string, ssh.PublicKey) {
 // cleanup.
 func StartServer(t testing.TB, authorizedKey ssh.PublicKey) int {
 	t.Helper()
+	return StartServerWithChannelHandler(t, authorizedKey, handleChannel)
+}
+
+// StartServerWithChannelHandler starts a server whose forwarding channels are
+// handled by handle. Tests can use it to model channel-open edge cases.
+func StartServerWithChannelHandler(
+	t testing.TB,
+	authorizedKey ssh.PublicKey,
+	handle func(ssh.NewChannel),
+) int {
+	t.Helper()
 
 	_, hostSigner := newEd25519Signer(t)
 	config := &ssh.ServerConfig{
@@ -81,7 +92,7 @@ func StartServer(t testing.TB, authorizedKey ssh.PublicKey) int {
 			if err != nil {
 				return // listener closed during cleanup
 			}
-			go handleSSHConn(conn, config)
+			go handleSSHConn(conn, config, handle)
 		}
 	}()
 
@@ -92,7 +103,7 @@ func StartServer(t testing.TB, authorizedKey ssh.PublicKey) int {
 	return addr.Port
 }
 
-func handleSSHConn(c net.Conn, config *ssh.ServerConfig) {
+func handleSSHConn(c net.Conn, config *ssh.ServerConfig, handle func(ssh.NewChannel)) {
 	sshConn, chans, reqs, err := ssh.NewServerConn(c, config)
 	if err != nil {
 		return // handshake/auth failure
@@ -102,14 +113,18 @@ func handleSSHConn(c net.Conn, config *ssh.ServerConfig) {
 	go ssh.DiscardRequests(reqs)
 
 	for nc := range chans {
-		switch nc.ChannelType() {
-		case "direct-tcpip":
-			go handleDirectTCPIP(nc)
-		case "direct-streamlocal@openssh.com":
-			go handleStreamLocal(nc)
-		default:
-			_ = nc.Reject(ssh.UnknownChannelType, "unsupported channel type")
-		}
+		go handle(nc)
+	}
+}
+
+func handleChannel(nc ssh.NewChannel) {
+	switch nc.ChannelType() {
+	case "direct-tcpip":
+		handleDirectTCPIP(nc)
+	case "direct-streamlocal@openssh.com":
+		handleStreamLocal(nc)
+	default:
+		_ = nc.Reject(ssh.UnknownChannelType, "unsupported channel type")
 	}
 }
 

--- a/internal/ssh/sshtest/server.go
+++ b/internal/ssh/sshtest/server.go
@@ -1,5 +1,8 @@
-//go:build e2e || integration
-
+// Package sshtest provides an in-process SSH bastion for tunnel tests. The
+// server authenticates a generated key and services the channel types a local
+// forward opens ("direct-tcpip" and "direct-streamlocal@openssh.com", the server
+// side of `ssh -L`), so a tunnel can forward through it to an arbitrary local
+// target without any external SSH daemon.
 package sshtest
 
 import (
@@ -48,9 +51,10 @@ func GenerateClientKey(t testing.TB) (string, ssh.PublicKey) {
 }
 
 // StartServer starts a minimal SSH server on a random localhost port that
-// authenticates the given key and handles "direct-tcpip" (ssh -L) channels so a
-// local forward works. It returns the listening port and tears the server down
-// on test cleanup.
+// authenticates the given key and handles the channel types a local forward uses
+// ("direct-tcpip" for `ssh -L`, "direct-streamlocal@openssh.com" for a unix
+// socket target). It returns the listening port and tears the server down on test
+// cleanup.
 func StartServer(t testing.TB, authorizedKey ssh.PublicKey) int {
 	t.Helper()
 
@@ -98,11 +102,14 @@ func handleSSHConn(c net.Conn, config *ssh.ServerConfig) {
 	go ssh.DiscardRequests(reqs)
 
 	for nc := range chans {
-		if nc.ChannelType() != "direct-tcpip" {
-			_ = nc.Reject(ssh.UnknownChannelType, "only direct-tcpip is supported")
-			continue
+		switch nc.ChannelType() {
+		case "direct-tcpip":
+			go handleDirectTCPIP(nc)
+		case "direct-streamlocal@openssh.com":
+			go handleStreamLocal(nc)
+		default:
+			_ = nc.Reject(ssh.UnknownChannelType, "unsupported channel type")
 		}
-		go handleDirectTCPIP(nc)
 	}
 }
 
@@ -119,9 +126,33 @@ func handleDirectTCPIP(nc ssh.NewChannel) {
 		_ = nc.Reject(ssh.ConnectionFailed, "bad direct-tcpip payload")
 		return
 	}
-
 	dest := net.JoinHostPort(payload.DestAddr, strconv.Itoa(int(payload.DestPort)))
-	target, err := net.Dial("tcp", dest)
+	serveChannel(nc, "tcp", dest)
+}
+
+// handleStreamLocal is the unix-socket counterpart of handleDirectTCPIP (the
+// server side of `ssh -L local:/path/to.sock`).
+func handleStreamLocal(nc ssh.NewChannel) {
+	var payload struct {
+		SocketPath  string
+		Reserved    string
+		ReservedU32 uint32
+	}
+	if err := ssh.Unmarshal(nc.ExtraData(), &payload); err != nil {
+		_ = nc.Reject(ssh.ConnectionFailed, "bad direct-streamlocal payload")
+		return
+	}
+	serveChannel(nc, "unix", payload.SocketPath)
+}
+
+// serveChannel pipes the channel to its target, passing each direction's EOF on as a
+// half-close the way a real sshd does.
+//
+// Deliberately its own copy loop rather than the production relay: the half-close
+// tests measure the tunnel against this fixture, and sharing that code would put the
+// same policy on both sides of the assertion, where a regression cancels out.
+func serveChannel(nc ssh.NewChannel, network, address string) {
+	target, err := net.Dial(network, address)
 	if err != nil {
 		_ = nc.Reject(ssh.ConnectionFailed, err.Error())
 		return
@@ -134,12 +165,25 @@ func handleDirectTCPIP(nc ssh.NewChannel) {
 	}
 	go ssh.DiscardRequests(chReqs)
 
+	done := make(chan struct{})
 	go func() {
-		_, _ = io.Copy(ch, target)
-		_ = ch.CloseWrite()
-	}()
-	go func() {
+		defer close(done)
 		_, _ = io.Copy(target, ch)
-		_ = target.Close()
+		closeWrite(target)
 	}()
+	_, _ = io.Copy(ch, target)
+	_ = ch.CloseWrite()
+	<-done
+
+	_ = ch.Close()
+	_ = target.Close()
+}
+
+// closeWrite mirrors libs.HalfClose, kept separate for the reason serveChannel gives.
+func closeWrite(conn net.Conn) {
+	if hc, ok := conn.(interface{ CloseWrite() error }); ok {
+		_ = hc.CloseWrite()
+		return
+	}
+	_ = conn.Close()
 }

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -9,13 +9,11 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
-	"github.com/rgzr/sshtun"
+	"golang.org/x/crypto/ssh"
 )
 
 var TunnelType string = "ssh"
@@ -35,168 +33,79 @@ type TunnelConfig struct {
 }
 
 func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) {
-	tunnelCfgJson, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Open a log file for the tunnel
 	target := strconv.Itoa(cfg.TargetPort)
 	if cfg.TargetSocket != "" {
 		target = strings.ReplaceAll(cfg.TargetSocket, string(os.PathSeparator), "_")
 	}
-	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssh-tunnel-%s-%s.log", cfg.SSHHost, target))
-	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare the command
-	cmd := exec.Command(os.Args[0], strconv.Itoa(os.Getppid()))
-
-	// LocalPort is unique per resource, giving each concurrent fork its own ready file.
-	readyFilePath := filepath.Join(os.TempDir(), fmt.Sprintf("ssh-tunnel-ready-%d-%d", os.Getpid(), cfg.LocalPort))
-	os.Remove(readyFilePath)
-	defer os.Remove(readyFilePath)
-
-	// Append ssh tunnel config environment variable to pass parameters to the child process
-	cmd.Env = append(
-		os.Environ(),
-		fmt.Sprintf("%s=%s", libs.TunnelTypeEnv, TunnelType),
-		fmt.Sprintf("%s=%s", libs.TunnelConfEnv, string(tunnelCfgJson)),
-		fmt.Sprintf("%s=%s", libs.TunnelReadyEnv, readyFilePath),
-	)
-
-	// Redirect stdout and stderr to log file
-	cmd.Stdout = tunnelLogFile
-	cmd.Stderr = tunnelLogFile
-
-	// Run the command in the background
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	if err = libs.WaitForReadyFile(ctx, cmd.Process.Pid, readyFilePath); err != nil {
-		return nil, fmt.Errorf("%w. check %s for more information", err, tunnelLogPath)
-	}
-
-	return cmd, nil
+	logName := fmt.Sprintf("ssh-tunnel-%s-%s.log", cfg.SSHHost, target)
+	return libs.ForkTunnel(ctx, TunnelType, logName, cfg)
 }
 
-func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
+func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) error {
 	var cfg TunnelConfig
 	if err := json.Unmarshal([]byte(cfgJson), &cfg); err != nil {
 		return err
 	}
 
-	// Watch parent process lifecycle ie. main terraform process
-	err = libs.WatchProcess(parentPid)
+	if err := libs.WatchProcess(parentPid); err != nil {
+		return err
+	}
+
+	return runTunnel(ctx, cfg)
+}
+
+func runTunnel(ctx context.Context, cfg TunnelConfig) error {
+	clientCfg, err := clientConfig(cfg)
 	if err != nil {
 		return err
 	}
 
+	sshPort := cfg.SSHPort
+	if sshPort == 0 {
+		sshPort = defaultSSHPort
+	}
 	localHost := cfg.LocalHost
 	if localHost == "" {
 		localHost = "localhost"
 	}
+	sshAddr := net.JoinHostPort(cfg.SSHHost, strconv.Itoa(sshPort))
+	localAddr := net.JoinHostPort(localHost, strconv.Itoa(cfg.LocalPort))
+	network, target := targetEndpoint(cfg)
+	log.Printf("starting tunnel: %s - %s - %s", localAddr, sshAddr, target)
 
-	target := fmt.Sprintf("%s:%d", cfg.TargetHost, cfg.TargetPort)
+	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	clients := &clientPool{dial: func(ctx context.Context) (*ssh.Client, error) {
+		return dialSSH(ctx, sshAddr, clientCfg)
+	}}
+	defer clients.close()
+
+	// Authenticate before reporting readiness.
+	if _, err := clients.get(runCtx); err != nil {
+		return fmt.Errorf("connect to SSH bastion %s: %w", sshAddr, err)
+	}
+	log.Printf("connected to %s", sshAddr)
+
+	listener, err := net.Listen("tcp", localAddr)
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", localAddr, err)
+	}
+	fwd := newForwarder(listener, clients, network, target)
+	defer fwd.Close()
+
+	if err := libs.SignalReadyIfRequested(); err != nil {
+		return err
+	}
+	log.Printf("SSH tunnel listening on %s", listener.Addr())
+	defer log.Println("stopping tunnel")
+
+	return fwd.Serve(runCtx)
+}
+
+func targetEndpoint(cfg TunnelConfig) (network, address string) {
 	if cfg.TargetSocket != "" {
-		target = cfg.TargetSocket
+		return "unix", cfg.TargetSocket
 	}
-	log.Printf("starting tunnel: %s:%d - %s:%d - %s", localHost, cfg.LocalPort, cfg.SSHHost, cfg.SSHPort, target)
-
-	sshTun := sshtun.New(cfg.LocalPort, cfg.SSHHost, cfg.TargetPort)
-	sshTun.SetPort(cfg.SSHPort)
-	sshTun.SetUser(cfg.SSHUser)
-	sshTun.SetLocalHost(localHost)
-	if cfg.TargetSocket != "" {
-		sshTun.SetRemoteEndpoint(sshtun.NewUnixEndpoint(cfg.TargetSocket))
-	} else {
-		sshTun.SetRemoteHost(cfg.TargetHost)
-	}
-
-	if cfg.SSHPassword != "" {
-		sshTun.SetPassword(cfg.SSHPassword)
-	}
-
-	if cfg.SSHKey != "" {
-		if _, err := os.Stat(cfg.SSHKey); err == nil {
-			if cfg.SSHKeyPassphrase != "" {
-				sshTun.SetEncryptedKeyFile(cfg.SSHKey, cfg.SSHKeyPassphrase)
-			} else {
-				sshTun.SetKeyFile(cfg.SSHKey)
-			}
-		} else {
-			if cfg.SSHKeyPassphrase != "" {
-				sshTun.SetEncryptedKeyReader(strings.NewReader(cfg.SSHKey), cfg.SSHKeyPassphrase)
-			} else {
-				sshTun.SetKeyReader(strings.NewReader(cfg.SSHKey))
-			}
-		}
-	}
-
-	// Channel to signal when the tunneled connection is fully established
-	// (SSH handshake complete + remote endpoint connected)
-	tunnelReady := make(chan struct{}, 1)
-
-	sshTun.SetTunneledConnState(func(tun *sshtun.SSHTun, state *sshtun.TunneledConnState) {
-		log.Printf("tunneled conn state: %+v", state)
-		if state.Ready {
-			select {
-			case tunnelReady <- struct{}{}:
-			default:
-			}
-		}
-	})
-
-	sshTun.SetConnState(func(tun *sshtun.SSHTun, state sshtun.ConnState) {
-		switch state {
-		case sshtun.StateStarting:
-			log.Println("tunnel connecting...")
-		case sshtun.StateStarted:
-			log.Println("tunnel listener ready, probing connection...")
-			// Probe the tunnel in a goroutine to trigger the SSH handshake.
-			// The local listener accepts immediately, but ssh.Dial happens lazily
-			// when the first connection is handled. We wait for TunneledConnState
-			// with Ready=true to know the full tunnel (SSH + remote) is established.
-			go func() {
-				addr := net.JoinHostPort(localHost, strconv.Itoa(cfg.LocalPort))
-				conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
-				if err != nil {
-					log.Printf("tunnel probe dial failed: %v", err)
-					return
-				}
-				// Wait for the SSH handshake and remote connection to complete
-				<-tunnelReady
-				log.Println("tunnel connected")
-				if readyPath := os.Getenv(libs.TunnelReadyEnv); readyPath != "" {
-					if err := libs.SignalReady(readyPath); err != nil {
-						log.Printf("failed to signal readiness: %v", err)
-					}
-				}
-				// Keep probe connection alive to maintain the SSH session,
-				// preventing re-authentication for subsequent connections.
-				// Cleaned up when the tunnel process exits.
-				_ = conn
-			}()
-		case sshtun.StateStopped:
-			log.Println("tunnel stopped")
-		}
-	})
-
-	// Handle interrupt signal
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c
-		log.Println("stopping tunnel: received interrupt signal")
-		sshTun.Stop()
-	}()
-
-	if err = sshTun.Start(ctx); err != nil {
-		log.Printf("tunnel error: %v", err)
-	}
-
-	return
+	return "tcp", net.JoinHostPort(cfg.TargetHost, strconv.Itoa(cfg.TargetPort))
 }

--- a/internal/ssh/tunnel.go
+++ b/internal/ssh/tunnel.go
@@ -94,6 +94,14 @@ func runTunnel(ctx context.Context, cfg TunnelConfig) error {
 	fwd := newForwarder(listener, clients, network, target)
 	defer fwd.Close()
 
+	// Preserve the readiness contract: the local listener is only useful once
+	// the bastion can also open a channel to the configured target.
+	probe, err := fwd.dialTarget(runCtx)
+	if err != nil {
+		return fmt.Errorf("connect to SSH target %s: %w", target, err)
+	}
+	_ = probe.Close()
+
 	if err := libs.SignalReadyIfRequested(); err != nil {
 		return err
 	}

--- a/internal/sshtest/doc.go
+++ b/internal/sshtest/doc.go
@@ -1,9 +1,0 @@
-// Package sshtest provides an in-process SSH bastion for tunnel tests. The
-// server authenticates a generated key and services "direct-tcpip" channels
-// (the server side of `ssh -L`), so a tunnel can forward through it to an
-// arbitrary local target without any external SSH daemon.
-//
-// The implementation lives in a build-tagged file (e2e || integration) so it is
-// only compiled into test binaries that need it; this untagged file keeps the
-// package buildable for `go build ./...` and linters when no tag is set.
-package sshtest

--- a/test/e2e/ssh_test.go
+++ b/test/e2e/ssh_test.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
 )
 
 const sshTargetBody = "tunnel-e2e-ok"

--- a/test/integration/main_test.go
+++ b/test/integration/main_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/runner"
 	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
-	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
 )
 
 // Helper-process re-exec scaffold.

--- a/test/integration/ssh_test.go
+++ b/test/integration/ssh_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	"github.com/dfns/terraform-provider-tunnel/internal/ssh"
-	"github.com/dfns/terraform-provider-tunnel/internal/sshtest"
+	"github.com/dfns/terraform-provider-tunnel/internal/ssh/sshtest"
 )
 
 const sshTargetBody = "tunnel-it-ok"


### PR DESCRIPTION
Replaces the `rgzr/sshtun` dependency behind `tunnel_ssh` with a forwarder built directly on `golang.org/x/crypto/ssh`, fixing `unexpected EOF` failures on connections whose peer closes mid-use.

- **Half-close instead of teardown-on-first-EOF.** `sshtun` cancelled both directions as soon as one reached EOF, so a target closing its side of a keep-alive connection killed an in-flight request on the other — how a `POST` through the tunnel to a Kubernetes API server died. Each direction now `CloseWrite()`s and the relay waits for both, matching `ssh -L`. `TestForwardPassesHalfCloseThrough` is the regression test.
- **One SSH connection per tunnel.** `internal/ssh/client.go` dials once and multiplexes every forwarded connection as a channel, with concurrent callers sharing a single in-flight handshake. `sshtun` re-dialed whenever its connection count fell back to zero, and those repeated handshakes are what tripped the bastion's `MaxStartups` throttle.
