### PR TITLE
chore(renovate): group azure-sdk-for-go and kubernetes packages

### DIFF
--- a/.github/renovate-config.js
+++ b/.github/renovate-config.js
@@ -30,6 +30,21 @@ module.exports = {
         "github.com/aws/smithy-go",
       ],
     },
+    {
+      groupName: "azure-sdk-for-go packages",
+      groupSlug: "azure-sdk-for-go",
+      matchDatasources: ["go"],
+      matchPackageNames: [
+        "github.com/Azure/azure-sdk-for-go/**",
+        "github.com/AzureAD/microsoft-authentication-library-for-go",
+      ],
+    },
+    {
+      groupName: "kubernetes packages",
+      groupSlug: "kubernetes",
+      matchDatasources: ["go"],
+      matchPackageNames: ["k8s.io/**", "sigs.k8s.io/**"],
+    },
   ],
   customManagers: [],
 };

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Terraform Provider: Tunnel
 
 [![GitHub Release](https://img.shields.io/github/v/release/dfns/terraform-provider-tunnel)](https://github.com/dfns/terraform-provider-tunnel/releases/latest)
-[![Go Report Card](https://goreportcard.com/badge/github.com/dfns/terraform-provider-tunnel)](https://goreportcard.com/report/github.com/dfns/terraform-provider-tunnel)
 [![Terraform Downloads](https://img.shields.io/terraform/provider/dt/5739?logo=terraform&logoColor=white&color=%23844FBA)](https://registry.terraform.io/providers/dfns/tunnel)
 [![GitHub Downloads](https://img.shields.io/github/downloads/dfns/terraform-provider-tunnel/total?logo=github)](https://github.com/dfns/terraform-provider-tunnel/releases)
 


### PR DESCRIPTION
Groups the Azure SDK and Kubernetes Go modules into single Renovate PRs, mirroring the existing `aws-sdk-go-v2` group, and removes a stale README badge.
