### PR TITLE
fix: unify tunnel fork lifecycle and reap failed startups

### DIFF
--- a/internal/kubernetes/tunnel.go
+++ b/internal/kubernetes/tunnel.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"strconv"
+	"sync"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -56,42 +56,8 @@ type ExecConfig struct {
 }
 
 func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) {
-	tunnelCfgJson, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Open a log file for the tunnel
-	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("k8s-tunnel-%s-%s-%d.log", cfg.Namespace, cfg.ServiceName, cfg.TargetPort))
-	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepare the command
-	cmd := exec.Command(os.Args[0], strconv.Itoa(os.Getppid()))
-
-	// Append tunnel config environment variable to pass parameters to the child process
-	cmd.Env = append(
-		os.Environ(),
-		fmt.Sprintf("%s=%s", libs.TunnelTypeEnv, TunnelType),
-		fmt.Sprintf("%s=%s", libs.TunnelConfEnv, string(tunnelCfgJson)),
-	)
-
-	// Redirect stdout and stderr to log file
-	cmd.Stdout = tunnelLogFile
-	cmd.Stderr = tunnelLogFile
-
-	// Run the command in the background
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	if err = libs.WaitForPort(cmd.Process.Pid, cfg.LocalHost, strconv.Itoa(cfg.LocalPort)); err != nil {
-		return nil, fmt.Errorf("%w. check %s for more information", err, tunnelLogPath)
-	}
-
-	return cmd, nil
+	logName := fmt.Sprintf("k8s-tunnel-%s-%s-%d.log", cfg.Namespace, cfg.ServiceName, cfg.TargetPort)
+	return libs.ForkTunnel(ctx, TunnelType, logName, cfg)
 }
 
 func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
@@ -221,6 +187,10 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 
 	stopChan := make(chan struct{}, 1)
 	readyChan := make(chan struct{})
+	// Both the interrupt handler and a failed readiness signal can stop the
+	// forwarder, and closing stopChan twice would panic.
+	var stopOnce sync.Once
+	stop := func() { stopOnce.Do(func() { close(stopChan) }) }
 
 	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
 
@@ -243,12 +213,20 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 	go func() {
 		<-c
 		log.Println("stopping tunnel: received interrupt signal")
-		close(stopChan)
+		stop()
 	}()
 
+	readyErr := make(chan error, 1)
 	go func() {
 		<-readyChan
 		log.Println("port forwarding is ready")
+		err := libs.SignalReadyIfRequested()
+		readyErr <- err
+		if err != nil {
+			// The parent will never see this tunnel as ready, so serving it is
+			// pointless: stop forwarding and let the error surface in the log.
+			stop()
+		}
 	}()
 
 	if err := pf.ForwardPorts(); err != nil {
@@ -256,5 +234,10 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 		return err
 	}
 
-	return nil
+	select {
+	case err := <-readyErr:
+		return err
+	default:
+		return nil
+	}
 }

--- a/internal/libs/watch.go
+++ b/internal/libs/watch.go
@@ -82,22 +82,39 @@ func terminate(proc *ps.Process) error {
 	return proc.SendSignal(syscall.SIGINT)
 }
 
-func WaitForPort(pid int, host string, port string) error {
+// SignalReadyWhenServing signals readiness once the local port accepts
+// connections. Tunnels driven by a client library that blocks for the tunnel's
+// lifetime cannot signal inline, so they observe their own listener instead.
+func SignalReadyWhenServing(ctx context.Context, host string, port string) error {
+	if err := waitForLocalPort(ctx, host, port); err != nil {
+		return err
+	}
+	return SignalReadyIfRequested()
+}
+
+func waitForLocalPort(ctx context.Context, host string, port string) error {
 	timeout := 30 * time.Second
-	deadline := time.Now().Add(timeout)
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
 	addr := net.JoinHostPort(host, port)
-	for time.Now().Before(deadline) {
-		if err := CheckProcessExists(pid); err != nil {
-			return fmt.Errorf("process exited unexpectedly: %w", err)
-		}
+
+	for {
 		conn, err := net.DialTimeout("tcp", addr, time.Second)
 		if err == nil {
 			conn.Close()
 			return nil
 		}
-		time.Sleep(500 * time.Millisecond)
+		select {
+		case <-waitCtx.Done():
+			if err := ctx.Err(); err != nil {
+				return fmt.Errorf("wait for tunnel port: %w", err)
+			}
+			return fmt.Errorf("port %s not accepting connections after %s", port, timeout)
+		case <-ticker.C:
+		}
 	}
-	return fmt.Errorf("port %s not accepting connections after %s", port, timeout)
 }
 
 func SignalReady(path string) error {

--- a/internal/libs/watch_test.go
+++ b/internal/libs/watch_test.go
@@ -1,0 +1,58 @@
+package libs
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestSignalReadyWhenServingSignalsOnceListenerAccepts(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	host, port, err := net.SplitHostPort(listener.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv(TunnelReadyEnv, readyPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := SignalReadyWhenServing(ctx, host, port); err != nil {
+		t.Fatalf("SignalReadyWhenServing() error = %v", err)
+	}
+
+	if data, err := os.ReadFile(readyPath); err != nil || string(data) != "ready" {
+		t.Fatalf("ready file = %q (err %v), want \"ready\"", data, err)
+	}
+}
+
+func TestSignalReadyWhenServingStaysSilentWhilePortIsClosed(t *testing.T) {
+	port, err := GetFreePort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	t.Setenv(TunnelReadyEnv, readyPath)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+	err = SignalReadyWhenServing(ctx, "127.0.0.1", strconv.Itoa(port))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SignalReadyWhenServing() error = %v, want deadline exceeded", err)
+	}
+
+	// A tunnel that never bound must not look ready to the parent.
+	if _, err := os.Stat(readyPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ready file stat error = %v, want not-exist", err)
+	}
+}

--- a/internal/ssm/session.go
+++ b/internal/ssm/session.go
@@ -10,8 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
-const DEFAULT_SSM_ENV_NAME = "AWS_SSM_START_SESSION_RESPONSE"
-
 // Default SSM document for port forwarding.
 const DefaultSSMDocument = "AWS-StartPortForwardingSessionToRemoteHost"
 
@@ -24,6 +22,10 @@ type TunnelConfig struct {
 	SSMRegion   string
 	TargetHost  string
 	TargetPort  string
+
+	// SessionParams is set by the parent to hand the started session to the
+	// forked child, and is unset everywhere else.
+	SessionParams *SessionParams `json:",omitempty"`
 }
 
 type SessionParams struct {

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -3,10 +3,11 @@ package ssm
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
-	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -30,59 +31,23 @@ func GetEndpoint(ctx context.Context, region string) (string, error) {
 }
 
 func ForkRemoteTunnel(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) (*exec.Cmd, error) {
-	// First we start a session using AWS SDK
-	// see https://github.com/aws/aws-cli/blob/master/awscli/customizations/sessionmanager.py#L104
+	// The session is started here rather than in the child so that credential
+	// resolution stays in the provider process, as the AWS CLI does before
+	// handing the response to the plugin, last checked at
+	// https://github.com/aws/aws-cli/blob/5ad8dc60682d72edf21be96f0a591402f91ee45e/awscli/customizations/sessionmanager.py
 	sessionParams, err := StartTunnelSession(ctx, awsCfg, cfg)
 	if err != nil {
 		return nil, err
 	}
-	sessionParamsJson, err := json.Marshal(sessionParams)
-	if err != nil {
-		return nil, err
-	}
+	cfg.SessionParams = &sessionParams
 
-	tunnelCfgJson, err := json.Marshal(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	// Open a log file for the tunnel
 	logPort := cfg.TargetPort
 	if logPort == "" {
 		logPort = cfg.LocalPort
 	}
-	tunnelLogPath := libs.TunnelLogPath(fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, logPort))
-	tunnelLogFile, err := os.OpenFile(tunnelLogPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return nil, err
-	}
+	logName := fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, logPort)
 
-	// Prepare the command
-	cmd := exec.Command(os.Args[0], strconv.Itoa(os.Getppid()))
-
-	// Append special environment variable to pass session parameters to the child process
-	// see https://github.com/aws/aws-cli/blob/master/awscli/customizations/sessionmanager.py#L140
-	cmd.Env = append(
-		os.Environ(),
-		fmt.Sprintf("%s=%s", libs.TunnelTypeEnv, TunnelType),
-		fmt.Sprintf("%s=%s", libs.TunnelConfEnv, string(tunnelCfgJson)),
-		fmt.Sprintf("%s=%s", DEFAULT_SSM_ENV_NAME, string(sessionParamsJson)),
-	)
-
-	// Redirect stdout and stderr to log file
-	cmd.Stdout = tunnelLogFile
-	cmd.Stderr = tunnelLogFile
-
-	// Run the command in the background
-	if err := cmd.Start(); err != nil {
-		return nil, err
-	}
-
-	if err = libs.WaitForPort(cmd.Process.Pid, "localhost", cfg.LocalPort); err != nil {
-		return nil, fmt.Errorf("%w. check %s for more information", err, tunnelLogPath)
-	}
-
-	return cmd, nil
+	return libs.ForkTunnel(ctx, TunnelType, logName, cfg)
 }
 
 func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
@@ -90,9 +55,17 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 	if err := json.Unmarshal([]byte(cfgJson), &cfg); err != nil {
 		return err
 	}
+	if cfg.SessionParams == nil {
+		return errors.New("missing SSM session parameters")
+	}
 
 	// Watch parent process lifecycle ie. main terraform process
 	err = libs.WatchProcess(parentPid)
+	if err != nil {
+		return err
+	}
+
+	sessionParamsJson, err := json.Marshal(cfg.SessionParams)
 	if err != nil {
 		return err
 	}
@@ -108,15 +81,27 @@ func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err 
 		return err
 	}
 
+	// Positional layout copied from the AWS CLI, last checked at
+	// https://github.com/aws/aws-cli/blob/5ad8dc60682d72edf21be96f0a591402f91ee45e/awscli/customizations/sessionmanager.py
+	// Newer CLIs hand the plugin an env var name here instead, but the vendored
+	// plugin only reads the response itself from this argument.
 	args := []string{
 		"session-manager-plugin",
-		os.Getenv(DEFAULT_SSM_ENV_NAME),
+		string(sessionParamsJson),
 		cfg.SSMRegion,
 		"StartSession",
 		cfg.SSMProfile,
 		string(sessionInputJson),
 		endpointUrl,
 	}
+
+	// The plugin blocks for the tunnel's lifetime and exposes no readiness hook,
+	// so readiness is reported from the outside once it binds the local port.
+	go func() {
+		if err := libs.SignalReadyWhenServing(ctx, "localhost", cfg.LocalPort); err != nil {
+			log.Printf("failed to signal tunnel readiness: %v", err)
+		}
+	}()
 
 	// call session-manager-plugin to start the tunnel
 	pluginSession.ValidateInputAndStartSession(args, os.Stdout)

--- a/test/integration/watch_test.go
+++ b/test/integration/watch_test.go
@@ -90,53 +90,9 @@ func TestInterruptTerminatesProcess(t *testing.T) {
 		"process still alive after Interrupt")
 }
 
-// TestWaitForPort covers the readiness probe SSM and Kubernetes forks use: it
-// returns once the port is reachable, and bails out immediately if the forked
-// process dies instead of blocking for the full timeout.
-func TestWaitForPort(t *testing.T) {
-	t.Run("returns once the port is reachable", func(t *testing.T) {
-		sleeper := spawnHelper(t, modeSleeper)
-
-		ln, err := net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatalf("listening: %v", err)
-		}
-		t.Cleanup(func() { _ = ln.Close() })
-		_, portStr, err := net.SplitHostPort(ln.Addr().String())
-		if err != nil {
-			t.Fatalf("splitting listener addr: %v", err)
-		}
-
-		if err := libs.WaitForPort(sleeper.Process.Pid, "127.0.0.1", portStr); err != nil {
-			t.Fatalf("WaitForPort: %v", err)
-		}
-	})
-
-	t.Run("fails fast when the process has exited", func(t *testing.T) {
-		sleeper := spawnHelper(t, modeSleeper)
-		pid := sleeper.Process.Pid
-		_ = sleeper.Process.Kill()
-		_ = sleeper.Wait()
-
-		port, err := libs.GetFreePort()
-		if err != nil {
-			t.Fatalf("allocating free port: %v", err)
-		}
-
-		start := time.Now()
-		err = libs.WaitForPort(pid, "127.0.0.1", strconv.Itoa(port))
-		if err == nil {
-			t.Fatal("expected an error once the process exited")
-		}
-		if elapsed := time.Since(start); elapsed > 10*time.Second {
-			t.Fatalf("WaitForPort did not fail fast: took %s", elapsed)
-		}
-	})
-}
-
-// TestWaitForReadyFile covers the readiness handshake the SSH fork uses: the
-// child SignalReady writes the sentinel file and WaitForReadyFile returns once
-// it appears, while a dead process aborts the wait promptly.
+// TestWaitForReadyFile covers the readiness handshake every tunnel fork uses:
+// the child SignalReady writes the sentinel file and WaitForReadyFile returns
+// once it appears, while a dead process aborts the wait promptly.
 func TestWaitForReadyFile(t *testing.T) {
 	t.Run("returns once the ready file exists", func(t *testing.T) {
 		sleeper := spawnHelper(t, modeSleeper)


### PR DESCRIPTION
Moves the SSM and Kubernetes tunnels onto `libs.ForkTunnel`, the shared fork already used by the SSH and Azure Bastion tunnels, replacing two hand-rolled copies of the fork logic and the defects they carried.
