### PR TITLE
fix(kubernetes): resolve service ports against ready pods

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,7 +95,7 @@ jobs:
           go-version-file: "go.mod"
           cache: true
       - run: go mod download
-      - run: go test -v -tags integration -timeout 120s ./test/integration/
+      - run: go test -v -count=1 -tags integration -timeout 120s ./test/integration/
 
   # End-to-end: build the real provider and drive it through `terraform apply`
   # against live fixtures, so OS-specific regressions in the fork/process-watch
@@ -125,15 +125,16 @@ jobs:
         with:
           terraform_version: "1.10.5"
           terraform_wrapper: false
-      - run: go test -v -tags e2e -run TestSSHTunnelE2E -timeout 10m ./test/e2e/
+      - run: go test -v -count=1 -tags e2e -run TestSSHTunnelE2E -timeout 10m ./test/e2e/
 
-  # tunnel_kubernetes against a kind cluster, forwarding to the built-in CoreDNS
-  # metrics endpoint. Linux-only: kind needs a Linux Docker host.
+  # tunnel_kubernetes against a kind cluster: the built-in CoreDNS metrics
+  # endpoint, plus fixture workloads covering service/target port resolution
+  # and ready-pod selection. Linux-only: kind needs a Linux Docker host.
   k8s-e2e:
     name: Kubernetes tunnel
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -149,6 +150,6 @@ jobs:
           cluster_name: tunnel-e2e
       - name: Wait for CoreDNS
         run: kubectl wait --for=condition=Available deploy/coredns -n kube-system --timeout=120s
-      - run: go test -v -tags e2e -run TestKubernetesTunnelE2E -timeout 10m ./test/e2e/
+      - run: go test -v -count=1 -tags e2e -run 'TestKubernetes.*E2E' -timeout 15m ./test/e2e/
         env:
           E2E_KUBE_CONTEXT: kind-tunnel-e2e

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -19,10 +19,10 @@ test:
 	go test -v -cover -timeout=120s -parallel=10 ./...
 
 test-integration:
-	go test -v -tags integration -timeout=120s ./test/integration/
+	go test -v -count=1 -tags integration -timeout=120s ./test/integration/
 
 test-e2e:
-	go test -v -tags e2e -timeout=10m ./test/e2e/
+	go test -v -count=1 -tags e2e -timeout=10m ./test/e2e/
 
 testacc:
 	TF_ACC=1 go test -v -cover -timeout 120m ./...

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ This provider uses a built-in SSH client and requires valid SSH credentials (key
 
 ### Kubernetes Port Forwarding
 
-Establishes a port-forwarding session to a service or pod within a Kubernetes cluster directly via the Kubernetes API.
+Establishes a port-forwarding session to a service within a Kubernetes cluster directly via the Kubernetes API.
 This provider interacts directly with the Kubernetes API, supporting standard kubeconfig authentication.
 
 ## Requirements

--- a/docs/data-sources/kubernetes.md
+++ b/docs/data-sources/kubernetes.md
@@ -44,8 +44,8 @@ resource "postgresql_database" "my_db" {
 ### Required
 
 - `namespace` (String) The namespace of the service.
-- `service_name` (String) The name of the service to forward ports to.
-- `target_port` (Number) The port on the service to forward to.
+- `service_name` (String) The name of the service to forward ports to. One ready pod is selected when the tunnel starts and is not re-selected, so the tunnel stops forwarding if that pod goes away.
+- `target_port` (Number) The port exposed by the service, between 1 and 65535. It is resolved to the pod's numeric or named `targetPort`; a port the service does not expose is forwarded directly to that port on the pod.
 
 ### Optional
 

--- a/docs/ephemeral-resources/kubernetes.md
+++ b/docs/ephemeral-resources/kubernetes.md
@@ -44,8 +44,8 @@ resource "postgresql_database" "my_db" {
 ### Required
 
 - `namespace` (String) The namespace of the service.
-- `service_name` (String) The name of the service to forward ports to.
-- `target_port` (Number) The port on the service to forward to.
+- `service_name` (String) The name of the service to forward ports to. One ready pod is selected when the tunnel starts and is not re-selected, so the tunnel stops forwarding if that pod goes away.
+- `target_port` (Number) The port exposed by the service, between 1 and 65535. It is resolved to the pod's numeric or named `targetPort`; a port the service does not expose is forwarded directly to that port on the pod.
 
 ### Optional
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,7 @@ provider "kubernetes" {
 
 ### Kubernetes Port Forwarding
 
-Establishes a port-forwarding session to a service or pod within a Kubernetes cluster directly via the Kubernetes API.
+Establishes a port-forwarding session to a service within a Kubernetes cluster directly via the Kubernetes API.
 This provider interacts directly with the Kubernetes API, supporting standard kubeconfig authentication.
 
 ```terraform

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
 	github.com/shirou/gopsutil/v4 v4.26.7
 	golang.org/x/crypto v0.54.0
+	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3
 	k8s.io/client-go v0.36.3
 )
@@ -104,7 +105,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.36.3 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.3 // indirect

--- a/internal/kubernetes/config.go
+++ b/internal/kubernetes/config.go
@@ -1,0 +1,115 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+type TunnelConfig struct {
+	Namespace   string
+	ServiceName string
+	TargetPort  int
+	LocalHost   string
+	LocalPort   int
+
+	// Kubernetes Configuration
+	Host                  string
+	Username              string
+	Password              string
+	Insecure              bool
+	TLSServerName         string
+	ClientCertificate     string
+	ClientKey             string
+	ClusterCACertificate  string
+	ConfigPaths           []string
+	ConfigPath            string
+	ConfigContext         string
+	ConfigContextAuthInfo string
+	ConfigContextCluster  string
+	Token                 string
+	ProxyURL              string
+	Exec                  *ExecConfig
+}
+
+type ExecConfig struct {
+	APIVersion string
+	Command    string
+	Env        map[string]string
+	Args       []string
+}
+
+// restConfig assembles the client configuration from kubeconfig files plus the
+// explicit overrides carried in the tunnel config.
+func (c TunnelConfig) restConfig() (*rest.Config, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	if len(c.ConfigPaths) > 0 {
+		loadingRules.Precedence = c.ConfigPaths
+	} else if c.ConfigPath != "" {
+		loadingRules.ExplicitPath = c.ConfigPath
+	}
+
+	overrides := &clientcmd.ConfigOverrides{}
+	if c.ConfigContext != "" {
+		overrides.CurrentContext = c.ConfigContext
+	}
+	if c.ConfigContextAuthInfo != "" {
+		overrides.Context.AuthInfo = c.ConfigContextAuthInfo
+	}
+	if c.ConfigContextCluster != "" {
+		overrides.Context.Cluster = c.ConfigContextCluster
+	}
+	if c.Token != "" {
+		overrides.AuthInfo.Token = c.Token
+	}
+	if c.Username != "" {
+		overrides.AuthInfo.Username = c.Username
+	}
+	if c.Password != "" {
+		overrides.AuthInfo.Password = c.Password
+	}
+	if c.ClientCertificate != "" {
+		overrides.AuthInfo.ClientCertificateData = []byte(c.ClientCertificate)
+	}
+	if c.ClientKey != "" {
+		overrides.AuthInfo.ClientKeyData = []byte(c.ClientKey)
+	}
+	if c.ClusterCACertificate != "" {
+		overrides.ClusterInfo.CertificateAuthorityData = []byte(c.ClusterCACertificate)
+	}
+	if c.Host != "" {
+		overrides.ClusterInfo.Server = c.Host
+	}
+	if c.Insecure {
+		overrides.ClusterInfo.InsecureSkipTLSVerify = true
+	}
+	if c.TLSServerName != "" {
+		overrides.ClusterInfo.TLSServerName = c.TLSServerName
+	}
+	if c.ProxyURL != "" {
+		overrides.ClusterInfo.ProxyURL = c.ProxyURL
+	}
+	if c.Exec != nil {
+		overrides.AuthInfo.Exec = &clientcmdapi.ExecConfig{
+			APIVersion:      c.Exec.APIVersion,
+			Command:         c.Exec.Command,
+			Args:            c.Exec.Args,
+			Env:             make([]clientcmdapi.ExecEnvVar, 0, len(c.Exec.Env)),
+			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
+		}
+		for k, v := range c.Exec.Env {
+			overrides.AuthInfo.Exec.Env = append(overrides.AuthInfo.Exec.Env, clientcmdapi.ExecEnvVar{
+				Name:  k,
+				Value: v,
+			})
+		}
+	}
+
+	clientConfig, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
+	if err != nil {
+		return nil, fmt.Errorf("load kubeconfig: %w", err)
+	}
+	return clientConfig, nil
+}

--- a/internal/kubernetes/endpoints.go
+++ b/internal/kubernetes/endpoints.go
@@ -1,0 +1,143 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+)
+
+// endpoint is the ready pod and numeric pod port selected for one forwarding
+// session.
+type endpoint struct {
+	Pod  string
+	Port int32
+}
+
+func (e endpoint) String() string {
+	return fmt.Sprintf("%s:%d", e.Pod, e.Port)
+}
+
+// resolveEndpoint deterministically picks one ready pod and its numeric port for
+// the lifetime of the tunnel.
+func resolveEndpoint(ctx context.Context, client kubernetes.Interface, cfg TunnelConfig) (endpoint, error) {
+	service, err := client.CoreV1().Services(cfg.Namespace).Get(ctx, cfg.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return endpoint{}, fmt.Errorf("get service %s/%s: %w", cfg.Namespace, cfg.ServiceName, err)
+	}
+	if len(service.Spec.Selector) == 0 {
+		return endpoint{}, fmt.Errorf("service %s/%s has no pod selector", cfg.Namespace, cfg.ServiceName)
+	}
+
+	servicePort := findServicePort(service, cfg.TargetPort)
+
+	selector := metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: service.Spec.Selector})
+	pods, err := client.CoreV1().Pods(cfg.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return endpoint{}, fmt.Errorf("list pods for service %s/%s: %w", cfg.Namespace, cfg.ServiceName, err)
+	}
+	sort.Slice(pods.Items, func(i, j int) bool { return pods.Items[i].Name < pods.Items[j].Name })
+
+	var portErr error
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if !podReady(pod) {
+			continue
+		}
+		port, err := resolvePodPort(pod, cfg.TargetPort, servicePort)
+		if err != nil {
+			portErr = err
+			continue
+		}
+		if servicePort == nil {
+			// Keep the original provider behavior: a target_port not exposed by
+			// the Service is treated as a pod port and forwarded unchanged. Named
+			// here so the warning includes the pod the tunnel actually bypasses to.
+			log.Printf(
+				"service %s/%s does not expose port %d (exposed: %s); treating %d as a pod port on %s",
+				cfg.Namespace, cfg.ServiceName, cfg.TargetPort,
+				describeServicePorts(service), cfg.TargetPort, pod.Name,
+			)
+		}
+		return endpoint{Pod: pod.Name, Port: port}, nil
+	}
+
+	// portErr is only ever set from a ready pod, so testing it first both reports
+	// the actionable failure and keeps this %w from wrapping a nil error.
+	if portErr != nil {
+		return endpoint{}, fmt.Errorf("resolve target port for service %s/%s: %w", cfg.Namespace, cfg.ServiceName, portErr)
+	}
+	return endpoint{}, fmt.Errorf("service %s/%s has no ready, non-terminating pods", cfg.Namespace, cfg.ServiceName)
+}
+
+// describeServicePorts lists the ports the Service does expose, so a mistyped
+// target_port is diagnosable from the tunnel log instead of degrading into a
+// bare connection failure.
+func describeServicePorts(service *corev1.Service) string {
+	if len(service.Spec.Ports) == 0 {
+		return "none"
+	}
+	described := make([]string, 0, len(service.Spec.Ports))
+	for _, port := range service.Spec.Ports {
+		if port.Name != "" {
+			described = append(described, fmt.Sprintf("%d (%s)", port.Port, port.Name))
+			continue
+		}
+		described = append(described, strconv.Itoa(int(port.Port)))
+	}
+	return strings.Join(described, ", ")
+}
+
+func findServicePort(service *corev1.Service, port int) *corev1.ServicePort {
+	for i := range service.Spec.Ports {
+		if int(service.Spec.Ports[i].Port) == port {
+			return &service.Spec.Ports[i]
+		}
+	}
+	return nil
+}
+
+func resolvePodPort(pod *corev1.Pod, configuredPort int, servicePort *corev1.ServicePort) (int32, error) {
+	if servicePort == nil {
+		return int32(configuredPort), nil
+	}
+	switch servicePort.TargetPort.Type {
+	case intstr.Int:
+		if servicePort.TargetPort.IntVal != 0 {
+			return servicePort.TargetPort.IntVal, nil
+		}
+		// Kubernetes defaults an omitted targetPort to the Service port.
+		return servicePort.Port, nil
+	case intstr.String:
+		name := servicePort.TargetPort.StrVal
+		for _, container := range pod.Spec.Containers {
+			for _, port := range container.Ports {
+				if port.Name == name {
+					return port.ContainerPort, nil
+				}
+			}
+		}
+		return 0, fmt.Errorf("pod %s has no container port named %q", pod.Name, name)
+	default:
+		return 0, fmt.Errorf("service port has unsupported targetPort %q", servicePort.TargetPort.String())
+	}
+}
+
+func podReady(pod *corev1.Pod) bool {
+	if pod.DeletionTimestamp != nil || pod.Status.Phase != corev1.PodRunning {
+		return false
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+	return false
+}

--- a/internal/kubernetes/endpoints_test.go
+++ b/internal/kubernetes/endpoints_test.go
@@ -1,0 +1,173 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"log"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testNamespace = "default"
+	testService   = "web"
+)
+
+func serviceConfig() TunnelConfig {
+	return TunnelConfig{Namespace: testNamespace, ServiceName: testService, TargetPort: 80}
+}
+
+func service(targetPort intstr.IntOrString) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: testService, Namespace: testNamespace},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "web"},
+			Ports:    []corev1.ServicePort{{Port: 80, TargetPort: targetPort}},
+		},
+	}
+}
+
+func pod(name string, ready bool, ports ...corev1.ContainerPort) *corev1.Pod {
+	readyStatus := corev1.ConditionFalse
+	if ready {
+		readyStatus = corev1.ConditionTrue
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name, Namespace: testNamespace, Labels: map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Ports: ports}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			Conditions: []corev1.PodCondition{{
+				Type: corev1.PodReady, Status: readyStatus,
+			}},
+		},
+	}
+}
+
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	captured := &bytes.Buffer{}
+	previous := log.Writer()
+	log.SetOutput(captured)
+	t.Cleanup(func() { log.SetOutput(previous) })
+	return captured
+}
+
+func TestResolveEndpointNumericTargetPort(t *testing.T) {
+	client := fake.NewClientset(service(intstr.FromInt32(8080)), pod("web-1", true))
+
+	got, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if want := (endpoint{Pod: "web-1", Port: 8080}); got != want {
+		t.Fatalf("endpoint = %v, want %v", got, want)
+	}
+}
+
+func TestResolveEndpointNamedTargetPort(t *testing.T) {
+	client := fake.NewClientset(
+		service(intstr.FromString("http")),
+		pod("web-1", true, corev1.ContainerPort{Name: "http", ContainerPort: 9090}),
+	)
+
+	got, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if want := (endpoint{Pod: "web-1", Port: 9090}); got != want {
+		t.Fatalf("endpoint = %v, want %v", got, want)
+	}
+}
+
+func TestResolveEndpointSkipsUnreadyAndTerminatingPods(t *testing.T) {
+	deleting := pod("web-0", true)
+	now := metav1.Now()
+	deleting.DeletionTimestamp = &now
+	client := fake.NewClientset(
+		service(intstr.FromInt32(8080)),
+		deleting,
+		pod("web-1", false),
+		pod("web-2", true),
+	)
+
+	got, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if got.Pod != "web-2" {
+		t.Fatalf("selected pod = %q, want web-2", got.Pod)
+	}
+}
+
+func TestResolveEndpointIsDeterministic(t *testing.T) {
+	client := fake.NewClientset(
+		service(intstr.FromInt32(8080)),
+		pod("web-z", true),
+		pod("web-a", true),
+	)
+
+	got, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if got.Pod != "web-a" {
+		t.Fatalf("selected pod = %q, want lexically first ready pod web-a", got.Pod)
+	}
+}
+
+func TestResolveEndpointReportsNoReadyPod(t *testing.T) {
+	client := fake.NewClientset(service(intstr.FromInt32(8080)), pod("web-1", false))
+
+	_, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err == nil || !strings.Contains(err.Error(), "no ready") {
+		t.Fatalf("resolveEndpoint() error = %v, want no-ready-pod error", err)
+	}
+}
+
+func TestResolveEndpointKeepsDirectPodPortFallback(t *testing.T) {
+	cfg := serviceConfig()
+	cfg.TargetPort = 9153
+	svc := service(intstr.FromInt32(8080))
+	svc.Spec.Ports[0].Name = "http"
+	client := fake.NewClientset(svc, pod("web-1", true))
+
+	logs := captureLogs(t)
+	got, err := resolveEndpoint(context.Background(), client, cfg)
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if got.Port != 9153 {
+		t.Fatalf("selected port = %d, want configured pod port 9153", got.Port)
+	}
+	// The warning is the only hint a mistyped target_port gets, so it has to name
+	// the ports the Service does expose and the pod this session resolved to.
+	for _, want := range []string{"does not expose port 9153", "80 (http)", "web-1"} {
+		if logged := logs.String(); !strings.Contains(logged, want) {
+			t.Fatalf("fallback warning = %q, want it to contain %q", logged, want)
+		}
+	}
+}
+
+func TestResolveEndpointTriesNextReadyPodForNamedPort(t *testing.T) {
+	client := fake.NewClientset(
+		service(intstr.FromString("http")),
+		pod("web-a", true),
+		pod("web-b", true, corev1.ContainerPort{Name: "http", ContainerPort: 9090}),
+	)
+
+	got, err := resolveEndpoint(context.Background(), client, serviceConfig())
+	if err != nil {
+		t.Fatalf("resolveEndpoint() error = %v", err)
+	}
+	if got.Pod != "web-b" || got.Port != 9090 {
+		t.Fatalf("endpoint = %v, want web-b:9090", got)
+	}
+}

--- a/internal/kubernetes/forward.go
+++ b/internal/kubernetes/forward.go
@@ -1,0 +1,106 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/portforward"
+	"k8s.io/client-go/transport/spdy"
+)
+
+type portForward struct {
+	endpoint endpoint
+	ready    <-chan struct{}
+	stop     chan struct{}
+	serve    func() error
+}
+
+func newPortForward(
+	clientConfig *rest.Config,
+	clientSet kubernetes.Interface,
+	cfg TunnelConfig,
+	ep endpoint,
+) (*portForward, error) {
+	transport, upgrader, err := spdy.RoundTripperFor(clientConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create round tripper: %w", err)
+	}
+	req := clientSet.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Namespace(cfg.Namespace).
+		Name(ep.Pod).
+		SubResource("portforward")
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
+
+	stopChan := make(chan struct{})
+	readyChan := make(chan struct{})
+	forwarder, err := portforward.NewOnAddresses(
+		dialer,
+		[]string{cfg.LocalHost},
+		[]string{fmt.Sprintf("%d:%d", cfg.LocalPort, ep.Port)},
+		stopChan,
+		readyChan,
+		os.Stdout,
+		os.Stderr,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create port forwarder: %w", err)
+	}
+	return &portForward{
+		endpoint: ep,
+		ready:    readyChan,
+		stop:     stopChan,
+		serve:    forwarder.ForwardPorts,
+	}, nil
+}
+
+func (f *portForward) run(ctx context.Context, signalReady func() error) error {
+	defer close(f.stop)
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- f.serve() }()
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-done:
+		return fmt.Errorf("start port forward to %s: %w", f.endpoint, endedError(err))
+	case <-f.ready:
+	}
+
+	// Readiness can win the select when cancellation happens at the same time.
+	if ctx.Err() != nil {
+		return nil
+	}
+
+	log.Printf("forwarding to %s", f.endpoint)
+	if err := signalReady(); err != nil {
+		return err
+	}
+	log.Println("kubernetes tunnel is ready")
+
+	select {
+	case <-ctx.Done():
+		return nil
+	case err := <-done:
+		return fmt.Errorf("port forward to %s ended: %w", f.endpoint, endedError(err))
+	}
+}
+
+// endedError names the cause when client-go stops forwarding without reporting
+// one, which would otherwise surface as an unexplained nil error.
+func endedError(err error) error {
+	if err == nil {
+		return errors.New("client-go stopped forwarding")
+	}
+	return err
+}

--- a/internal/kubernetes/forward_test.go
+++ b/internal/kubernetes/forward_test.go
@@ -1,0 +1,132 @@
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func readyChannel() <-chan struct{} {
+	ready := make(chan struct{})
+	close(ready)
+	return ready
+}
+
+var testEndpoint = endpoint{Pod: "web-1", Port: 8080}
+
+func testPortForward(ready <-chan struct{}, run func(<-chan struct{}) error) *portForward {
+	stopped := make(chan struct{})
+	return &portForward{
+		endpoint: testEndpoint,
+		ready:    ready,
+		stop:     stopped,
+		serve:    func() error { return run(stopped) },
+	}
+}
+
+func TestPortForwardReturnsErrorWhenSelectedPodEnds(t *testing.T) {
+	want := errors.New("lost connection to pod")
+	end := make(chan struct{})
+	readyCalls := 0
+	forward := testPortForward(readyChannel(), func(stopped <-chan struct{}) error {
+		select {
+		case <-end:
+			return want
+		case <-stopped:
+			return nil
+		}
+	})
+
+	err := forward.run(context.Background(), func() error {
+		readyCalls++
+		close(end)
+		return nil
+	})
+
+	if !errors.Is(err, want) {
+		t.Fatalf("run() error = %v, want %v", err, want)
+	}
+	if !strings.Contains(err.Error(), "web-1:8080") {
+		t.Fatalf("run() error = %v, want selected endpoint", err)
+	}
+	if readyCalls != 1 {
+		t.Fatalf("readiness signaled %d times, want once", readyCalls)
+	}
+}
+
+func TestPortForwardFailsBeforeReadiness(t *testing.T) {
+	forward := testPortForward(make(chan struct{}), func(<-chan struct{}) error { return nil })
+	err := forward.run(context.Background(), func() error {
+		t.Fatal("signaled readiness")
+		return nil
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "start port forward to web-1:8080") {
+		t.Fatalf("run() error = %v, want pre-readiness failure", err)
+	}
+	if !strings.Contains(err.Error(), "client-go stopped forwarding") {
+		t.Fatalf("run() error = %v, want the unreported-cause reason", err)
+	}
+}
+
+func TestPortForwardReturnsSignalReadyErrorAndStops(t *testing.T) {
+	want := errors.New("write ready file: permission denied")
+	ended := make(chan struct{})
+	forward := testPortForward(readyChannel(), func(stopped <-chan struct{}) error {
+		<-stopped
+		close(ended)
+		return nil
+	})
+
+	err := forward.run(context.Background(), func() error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("run() error = %v, want %v", err, want)
+	}
+	select {
+	case <-ended:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve() left the port forward running")
+	}
+}
+
+func TestPortForwardNeverAdvertisesACancelledTunnel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	forward := testPortForward(readyChannel(), func(stopped <-chan struct{}) error {
+		<-stopped
+		return nil
+	})
+
+	err := forward.run(ctx, func() error {
+		t.Fatal("signaled readiness for a cancelled tunnel")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil on cancellation", err)
+	}
+}
+
+func TestPortForwardStopsCleanlyOnCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	ended := make(chan struct{})
+	forward := testPortForward(readyChannel(), func(stopped <-chan struct{}) error {
+		<-stopped
+		close(ended)
+		return nil
+	})
+
+	err := forward.run(ctx, func() error {
+		cancel()
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("run() error = %v, want nil", err)
+	}
+	select {
+	case <-ended:
+	case <-time.After(2 * time.Second):
+		t.Fatal("serve() did not stop the port forward")
+	}
+}

--- a/internal/kubernetes/tunnel.go
+++ b/internal/kubernetes/tunnel.go
@@ -5,239 +5,59 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
-	"sync"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"k8s.io/client-go/tools/portforward"
-	"k8s.io/client-go/transport/spdy"
 )
 
 var TunnelType string = "kubernetes"
-
-type TunnelConfig struct {
-	Namespace   string
-	ServiceName string
-	TargetPort  int
-	LocalHost   string
-	LocalPort   int
-
-	// Kubernetes Configuration
-	Host                  string
-	Username              string
-	Password              string
-	Insecure              bool
-	TLSServerName         string
-	ClientCertificate     string
-	ClientKey             string
-	ClusterCACertificate  string
-	ConfigPaths           []string
-	ConfigPath            string
-	ConfigContext         string
-	ConfigContextAuthInfo string
-	ConfigContextCluster  string
-	Token                 string
-	ProxyURL              string
-	Exec                  *ExecConfig
-}
-
-type ExecConfig struct {
-	APIVersion string
-	Command    string
-	Env        map[string]string
-	Args       []string
-}
 
 func ForkRemoteTunnel(ctx context.Context, cfg TunnelConfig) (*exec.Cmd, error) {
 	logName := fmt.Sprintf("k8s-tunnel-%s-%s-%d.log", cfg.Namespace, cfg.ServiceName, cfg.TargetPort)
 	return libs.ForkTunnel(ctx, TunnelType, logName, cfg)
 }
 
-func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {
+func StartRemoteTunnel(ctx context.Context, cfgJSON string, parentPID int) error {
 	var cfg TunnelConfig
-	if err := json.Unmarshal([]byte(cfgJson), &cfg); err != nil {
+	if err := json.Unmarshal([]byte(cfgJSON), &cfg); err != nil {
 		return err
 	}
+	if err := libs.WatchProcess(parentPID); err != nil {
+		return err
+	}
+	return runTunnel(ctx, cfg)
+}
 
-	// Watch parent process lifecycle ie. main terraform process
-	err = libs.WatchProcess(parentPid)
+func runTunnel(ctx context.Context, cfg TunnelConfig) error {
+	log.Printf(
+		"starting tunnel: %s:%d -> %s/%s:%d",
+		cfg.LocalHost, cfg.LocalPort, cfg.Namespace, cfg.ServiceName, cfg.TargetPort,
+	)
+
+	clientConfig, err := cfg.restConfig()
 	if err != nil {
 		return err
 	}
-
-	log.Printf("starting tunnel: %s:%d -> %s/%s:%d", cfg.LocalHost, cfg.LocalPort, cfg.Namespace, cfg.ServiceName, cfg.TargetPort)
-
-	// Load kubeconfig
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if len(cfg.ConfigPaths) > 0 {
-		loadingRules.Precedence = cfg.ConfigPaths
-	} else if cfg.ConfigPath != "" {
-		loadingRules.ExplicitPath = cfg.ConfigPath
-	}
-
-	configOverrides := &clientcmd.ConfigOverrides{}
-	if cfg.ConfigContext != "" {
-		configOverrides.CurrentContext = cfg.ConfigContext
-	}
-	if cfg.ConfigContextAuthInfo != "" {
-		configOverrides.Context.AuthInfo = cfg.ConfigContextAuthInfo
-	}
-	if cfg.ConfigContextCluster != "" {
-		configOverrides.Context.Cluster = cfg.ConfigContextCluster
-	}
-	if cfg.Token != "" {
-		configOverrides.AuthInfo.Token = cfg.Token
-	}
-	if cfg.Username != "" {
-		configOverrides.AuthInfo.Username = cfg.Username
-	}
-	if cfg.Password != "" {
-		configOverrides.AuthInfo.Password = cfg.Password
-	}
-	if cfg.ClientCertificate != "" {
-		configOverrides.AuthInfo.ClientCertificateData = []byte(cfg.ClientCertificate)
-	}
-	if cfg.ClientKey != "" {
-		configOverrides.AuthInfo.ClientKeyData = []byte(cfg.ClientKey)
-	}
-	if cfg.ClusterCACertificate != "" {
-		configOverrides.ClusterInfo.CertificateAuthorityData = []byte(cfg.ClusterCACertificate)
-	}
-	if cfg.Host != "" {
-		configOverrides.ClusterInfo.Server = cfg.Host
-	}
-	if cfg.Insecure {
-		configOverrides.ClusterInfo.InsecureSkipTLSVerify = true
-	}
-	if cfg.TLSServerName != "" {
-		configOverrides.ClusterInfo.TLSServerName = cfg.TLSServerName
-	}
-	if cfg.ProxyURL != "" {
-		configOverrides.ClusterInfo.ProxyURL = cfg.ProxyURL
-	}
-	if cfg.Exec != nil {
-		configOverrides.AuthInfo.Exec = &clientcmdapi.ExecConfig{
-			APIVersion:      cfg.Exec.APIVersion,
-			Command:         cfg.Exec.Command,
-			Args:            cfg.Exec.Args,
-			Env:             make([]clientcmdapi.ExecEnvVar, 0, len(cfg.Exec.Env)),
-			InteractiveMode: clientcmdapi.IfAvailableExecInteractiveMode,
-		}
-		for k, v := range cfg.Exec.Env {
-			configOverrides.AuthInfo.Exec.Env = append(configOverrides.AuthInfo.Exec.Env, clientcmdapi.ExecEnvVar{
-				Name:  k,
-				Value: v,
-			})
-		}
-	}
-
-	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
-
-	clientConfig, err := kubeConfig.ClientConfig()
-	if err != nil {
-		return fmt.Errorf("failed to load kubeconfig: %w", err)
-	}
-
-	// Create Kubernetes Clientset
 	clientSet, err := kubernetes.NewForConfig(clientConfig)
 	if err != nil {
-		return fmt.Errorf("failed to create k8s client: %w", err)
+		return fmt.Errorf("create k8s client: %w", err)
 	}
 
-	transport, upgrader, err := spdy.RoundTripperFor(clientConfig)
+	runCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	ep, err := resolveEndpoint(runCtx, clientSet, cfg)
 	if err != nil {
-		return fmt.Errorf("failed to create round tripper: %w", err)
+		return err
 	}
-
-	// Get the service to find the selector
-	service, err := clientSet.CoreV1().Services(cfg.Namespace).Get(ctx, cfg.ServiceName, metav1.GetOptions{})
+	forward, err := newPortForward(clientConfig, clientSet, cfg, ep)
 	if err != nil {
-		return fmt.Errorf("failed to get service %s: %w", cfg.ServiceName, err)
-	}
-
-	// List pods matching the service selector
-	selector := metav1.FormatLabelSelector(&metav1.LabelSelector{MatchLabels: service.Spec.Selector})
-	pods, err := clientSet.CoreV1().Pods(cfg.Namespace).List(ctx, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return fmt.Errorf("failed to list pods for service %s: %w", cfg.ServiceName, err)
-	}
-
-	if len(pods.Items) == 0 {
-		return fmt.Errorf("no pods found for service %s", cfg.ServiceName)
-	}
-
-	// Pick the first pod
-	podName := pods.Items[0].Name
-	log.Printf("forwarding to pod: %s", podName)
-
-	// Create portforward request
-	req := clientSet.RESTClient().Post().
-		Prefix("api/v1").
-		Resource("pods").
-		Namespace(cfg.Namespace).
-		Name(podName).
-		SubResource("portforward")
-
-	stopChan := make(chan struct{}, 1)
-	readyChan := make(chan struct{})
-	// Both the interrupt handler and a failed readiness signal can stop the
-	// forwarder, and closing stopChan twice would panic.
-	var stopOnce sync.Once
-	stop := func() { stopOnce.Do(func() { close(stopChan) }) }
-
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, "POST", req.URL())
-
-	pf, err := portforward.NewOnAddresses(
-		dialer,
-		[]string{cfg.LocalHost},
-		[]string{fmt.Sprintf("%d:%d", cfg.LocalPort, cfg.TargetPort)},
-		stopChan,
-		readyChan,
-		os.Stdout,
-		os.Stderr,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to create port forwarder: %w", err)
-	}
-
-	// Handle interrupt signal
-	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	go func() {
-		<-c
-		log.Println("stopping tunnel: received interrupt signal")
-		stop()
-	}()
-
-	readyErr := make(chan error, 1)
-	go func() {
-		<-readyChan
-		log.Println("port forwarding is ready")
-		err := libs.SignalReadyIfRequested()
-		readyErr <- err
-		if err != nil {
-			// The parent will never see this tunnel as ready, so serving it is
-			// pointless: stop forwarding and let the error surface in the log.
-			stop()
-		}
-	}()
-
-	if err := pf.ForwardPorts(); err != nil {
-		log.Printf("port forwarding failed: %v", err)
 		return err
 	}
 
-	select {
-	case err := <-readyErr:
-		return err
-	default:
-		return nil
-	}
+	defer log.Println("stopping tunnel")
+	return forward.run(runCtx, libs.SignalReadyIfRequested)
 }

--- a/internal/provider/data_source_kubernetes.go
+++ b/internal/provider/data_source_kubernetes.go
@@ -32,11 +32,11 @@ func (d *KubernetesDataSource) Schema(ctx context.Context, req datasource.Schema
 				Required:    true,
 			},
 			"service_name": schema.StringAttribute{
-				Description: "The name of the service to forward ports to.",
+				Description: "The name of the service to forward ports to. One ready pod is selected when the tunnel starts and is not re-selected, so the tunnel stops forwarding if that pod goes away.",
 				Required:    true,
 			},
 			"target_port": schema.Int64Attribute{
-				Description: "The port on the service to forward to.",
+				Description: "The port exposed by the service, between 1 and 65535. It is resolved to the pod's numeric or named `targetPort`; a port the service does not expose is forwarded directly to that port on the pod.",
 				Required:    true,
 			},
 			"local_host": schema.StringAttribute{

--- a/internal/provider/ephemeral_kubernetes.go
+++ b/internal/provider/ephemeral_kubernetes.go
@@ -35,11 +35,11 @@ func (d *KubernetesEphemeral) Schema(ctx context.Context, req ephemeral.SchemaRe
 				Required:    true,
 			},
 			"service_name": schema.StringAttribute{
-				Description: "The name of the service to forward ports to.",
+				Description: "The name of the service to forward ports to. One ready pod is selected when the tunnel starts and is not re-selected, so the tunnel stops forwarding if that pod goes away.",
 				Required:    true,
 			},
 			"target_port": schema.Int64Attribute{
-				Description: "The port on the service to forward to.",
+				Description: "The port exposed by the service, between 1 and 65535. It is resolved to the pod's numeric or named `targetPort`; a port the service does not expose is forwarded directly to that port on the pod.",
 				Required:    true,
 			},
 			"local_host": schema.StringAttribute{

--- a/internal/provider/kubernetes.go
+++ b/internal/provider/kubernetes.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
 	k8s "github.com/dfns/terraform-provider-tunnel/internal/kubernetes"
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
@@ -49,7 +50,26 @@ type ExecConfigModel struct {
 func kubernetesConfig(ctx context.Context, data *KubernetesModel) (k8s.TunnelConfig, diag.Diagnostics) {
 	var diags diag.Diagnostics
 
-	localPort := int(data.LocalPort.ValueInt64())
+	targetPort := data.TargetPort.ValueInt64()
+	if targetPort < 1 || targetPort > 65535 {
+		diags.AddError(
+			"Invalid Kubernetes target port",
+			fmt.Sprintf("target_port must be between 1 and 65535, got %d", targetPort),
+		)
+		return k8s.TunnelConfig{}, diags
+	}
+
+	// A zero local_port means "allocate one", so only an explicit value is checked.
+	requestedLocalPort := data.LocalPort.ValueInt64()
+	if requestedLocalPort < 0 || requestedLocalPort > 65535 {
+		diags.AddError(
+			"Invalid Kubernetes local port",
+			fmt.Sprintf("local_port must be between 1 and 65535, got %d", requestedLocalPort),
+		)
+		return k8s.TunnelConfig{}, diags
+	}
+
+	localPort := int(requestedLocalPort)
 	if localPort == 0 {
 		var err error
 		localPort, err = libs.GetFreePort()
@@ -67,7 +87,7 @@ func kubernetesConfig(ctx context.Context, data *KubernetesModel) (k8s.TunnelCon
 	cfg := k8s.TunnelConfig{
 		Namespace:   data.Namespace.ValueString(),
 		ServiceName: data.ServiceName.ValueString(),
-		TargetPort:  int(data.TargetPort.ValueInt64()),
+		TargetPort:  int(targetPort),
 		LocalHost:   data.LocalHost.ValueString(),
 		LocalPort:   localPort,
 	}

--- a/internal/provider/kubernetes_test.go
+++ b/internal/provider/kubernetes_test.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
@@ -34,6 +36,40 @@ func TestKubernetesConfigDefaults(t *testing.T) {
 	}
 	if data.LocalHost.ValueString() != cfg.LocalHost || data.LocalPort.ValueInt64() != int64(cfg.LocalPort) {
 		t.Fatalf("model not updated: %+v", data)
+	}
+}
+
+func TestKubernetesConfigRejectsInvalidTargetPort(t *testing.T) {
+	for _, port := range []int64{-1, 0, 65536, 4294967297} {
+		t.Run(fmt.Sprintf("port_%d", port), func(t *testing.T) {
+			data := minimalKubernetesModel()
+			data.TargetPort = types.Int64Value(port)
+
+			cfg, diags := kubernetesConfig(context.Background(), &data)
+			if !diags.HasError() {
+				t.Fatalf("target_port %d accepted with config %+v", port, cfg)
+			}
+			if !strings.Contains(diags.Errors()[0].Detail(), "between 1 and 65535") {
+				t.Fatalf("diagnostic = %v, want valid port range", diags)
+			}
+		})
+	}
+}
+
+func TestKubernetesConfigRejectsInvalidLocalPort(t *testing.T) {
+	for _, port := range []int64{-1, 65536, 4294967297} {
+		t.Run(fmt.Sprintf("port_%d", port), func(t *testing.T) {
+			data := minimalKubernetesModel()
+			data.LocalPort = types.Int64Value(port)
+
+			cfg, diags := kubernetesConfig(context.Background(), &data)
+			if !diags.HasError() {
+				t.Fatalf("local_port %d accepted with config %+v", port, cfg)
+			}
+			if !strings.Contains(diags.Errors()[0].Detail(), "between 1 and 65535") {
+				t.Fatalf("diagnostic = %v, want valid port range", diags)
+			}
+		})
 	}
 }
 

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -87,7 +87,7 @@ This provider uses a built-in SSH client and requires valid SSH credentials (key
 
 ### Kubernetes Port Forwarding
 
-Establishes a port-forwarding session to a service or pod within a Kubernetes cluster directly via the Kubernetes API.
+Establishes a port-forwarding session to a service within a Kubernetes cluster directly via the Kubernetes API.
 This provider interacts directly with the Kubernetes API, supporting standard kubeconfig authentication.
 
 {{tffile "examples/data-sources/tunnel_kubernetes/data-source.tf"}}

--- a/test/e2e/k8s_test.go
+++ b/test/e2e/k8s_test.go
@@ -3,116 +3,79 @@
 package e2e
 
 import (
+	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dfns/terraform-provider-tunnel/internal/libs"
 )
 
-// TestKubernetesTunnelE2E drives the tunnel_kubernetes data source against a
-// real cluster (a kind cluster in CI). It forwards to the built-in CoreDNS
-// service (kube-system/kube-dns) on its Prometheus metrics port and asserts a
-// real HTTP request reaches the pod. Reusing CoreDNS means no workload to
-// deploy. Skips if no kubeconfig is available (e.g. SSH-only runners).
-func TestKubernetesTunnelE2E(t *testing.T) {
-	kubeconfig := resolveKubeconfig(t)
-	kubeContext := os.Getenv("E2E_KUBE_CONTEXT")
+// Fixture workloads reuse the CoreDNS image the cluster is already running,
+// configured as a bare Prometheus endpoint. That keeps these tests free of any
+// external image to pull, pin, or keep up to date.
+const (
+	// The service exposes a different port, so a tunnel that ignores targetPort
+	// cannot reach this one.
+	fixtureMetricsPort = 8080
+	fixtureServicePort = 80
+	// Where the deliberately broken workload serves instead, leaving
+	// fixtureMetricsPort closed so its readiness probe and any tunnel both fail.
+	fixtureWrongPort = 8090
+)
 
-	// Auto-assigned local port: the provider picks a free port (the common case).
-	t.Run("auto_port", func(t *testing.T) {
-		runKubernetesTunnelCase(t, kubeconfig, kubeContext, 0)
-	})
-
-	// Explicit local port: the provider must honor a caller-supplied port rather
-	// than allocating one (the local_port != 0 branch in the data source Read).
-	t.Run("explicit_port", func(t *testing.T) {
-		port, err := libs.GetFreePort()
-		if err != nil {
-			t.Fatalf("allocating free port: %v", err)
-		}
-		runKubernetesTunnelCase(t, kubeconfig, kubeContext, port)
-	})
+// kubeFixture addresses either a pre-existing service or a throwaway one.
+type kubeFixture struct {
+	kubeconfig  string
+	kubeContext string
+	namespace   string
+	service     string
 }
 
-// runKubernetesTunnelCase applies a tunnel_kubernetes config, verifies a real
-// request flows through the tunnel, and checks the forked process self-terminates.
-// requestedPort == 0 lets the provider choose the local port; otherwise the
-// provider must bind exactly requestedPort.
-func runKubernetesTunnelCase(t *testing.T, kubeconfig, kubeContext string, requestedPort int) {
+func existingServiceFixture(t *testing.T, namespace, service string) kubeFixture {
 	t.Helper()
-
-	contextLine := ""
-	if kubeContext != "" {
-		contextLine = fmt.Sprintf("\n    config_context = %q", kubeContext)
+	return kubeFixture{
+		kubeconfig:  resolveKubeconfig(t),
+		kubeContext: os.Getenv("E2E_KUBE_CONTEXT"),
+		namespace:   namespace,
+		service:     service,
 	}
-
-	localPortLine := ""
-	if requestedPort != 0 {
-		localPortLine = fmt.Sprintf("\n  local_port   = %d", requestedPort)
-	}
-
-	moduleDir := t.TempDir()
-
-	config := fmt.Sprintf(`
-terraform {
-  required_providers {
-    tunnel = {
-      source = "dfns/tunnel"
-    }
-  }
 }
 
-data "tunnel_kubernetes" "t" {
-  namespace    = "kube-system"
-  service_name = "kube-dns"
-  target_port  = 9153%s
-  kubernetes = {
-    config_path = %q%s
-  }
+func (f kubeFixture) inNamespace(namespace string) kubeFixture {
+	f.namespace = namespace
+	return f
 }
 
-resource "terraform_data" "probe" {
-  input = data.tunnel_kubernetes.t.local_port
-  provisioner "local-exec" {
-    command = "curl -fsS -o resp.txt http://${data.tunnel_kubernetes.t.local_host}:${data.tunnel_kubernetes.t.local_port}/metrics"
-  }
+// freshNamespaceFixture creates a throwaway namespace and tears it down with the
+// test.
+func freshNamespaceFixture(t *testing.T, namespace string) kubeFixture {
+	t.Helper()
+	fixture := existingServiceFixture(t, namespace, "tunnel-e2e")
+
+	// Namespace creation and teardown cannot run inside the namespace itself.
+	cluster := fixture.inNamespace("default")
+	// A namespace left behind by an interrupted run would fail the create below.
+	cluster.kubectl(t, "delete", "namespace", namespace, "--ignore-not-found", "--wait=true")
+	cluster.kubectl(t, "create", "namespace", namespace)
+	t.Cleanup(func() {
+		bin, err := exec.LookPath("kubectl")
+		if err != nil {
+			return
+		}
+		args := cluster.kubectlArgs("delete", "namespace", namespace, "--ignore-not-found", "--wait=false")
+		_ = exec.Command(bin, args...).Run()
+	})
+
+	return fixture
 }
 
-output "local_port" {
-  value = data.tunnel_kubernetes.t.local_port
-}
-`, localPortLine, filepath.ToSlash(kubeconfig), contextLine)
-
-	terraformApply(t, moduleDir, config)
-
-	got, err := os.ReadFile(filepath.Join(moduleDir, "resp.txt"))
-	if err != nil {
-		t.Fatalf("reading tunneled response: %v", err)
-	}
-	// CoreDNS exposes Prometheus metrics; the body must contain HELP markers.
-	if !strings.Contains(string(got), "# HELP") {
-		t.Fatalf("k8s tunnel /metrics response missing Prometheus markers; got %d bytes:\n%.300s", len(got), got)
-	}
-
-	localPort, err := strconv.Atoi(terraformOutput(t, moduleDir, "local_port"))
-	if err != nil {
-		t.Fatalf("parsing local_port output: %v", err)
-	}
-	if requestedPort != 0 && localPort != requestedPort {
-		t.Fatalf("provider bound local_port %d, want the requested %d", localPort, requestedPort)
-	}
-
-	// terraform has exited, so the forked tunnel must self-terminate and free
-	// its local port (the WatchProcess half of the cross-OS process handling).
-	assertTunnelTerminated(t, "localhost", localPort)
-}
-
-// resolveKubeconfig returns the kubeconfig path from KUBECONFIG (first entry) or
-// ~/.kube/config, skipping the test when neither exists.
+// resolveKubeconfig prefers the first KUBECONFIG entry over ~/.kube/config.
 func resolveKubeconfig(t *testing.T) string {
 	t.Helper()
 
@@ -121,7 +84,6 @@ func resolveKubeconfig(t *testing.T) string {
 			return first
 		}
 	}
-
 	if home, err := os.UserHomeDir(); err == nil {
 		def := filepath.Join(home, ".kube", "config")
 		if _, err := os.Stat(def); err == nil {
@@ -131,4 +93,336 @@ func resolveKubeconfig(t *testing.T) string {
 
 	t.Skip("no kubeconfig found (set KUBECONFIG or ~/.kube/config); skipping k8s E2E test")
 	return ""
+}
+
+// kubectlArgs keeps Go helpers and Terraform's local-exec commands pointed at
+// the same cluster and namespace.
+func (f kubeFixture) kubectlArgs(args ...string) []string {
+	flags := []string{"--kubeconfig", f.kubeconfig}
+	if f.kubeContext != "" {
+		flags = append(flags, "--context", f.kubeContext)
+	}
+	flags = append(flags, "--namespace", f.namespace)
+	return append(flags, args...)
+}
+
+func (f kubeFixture) kubectl(t *testing.T, args ...string) string {
+	t.Helper()
+	return f.kubectlStdin(t, "", args...)
+}
+
+func (f kubeFixture) kubectlStdin(t *testing.T, stdin string, args ...string) string {
+	t.Helper()
+	bin, err := exec.LookPath("kubectl")
+	if err != nil {
+		t.Skip("kubectl not found in PATH; skipping k8s E2E test")
+	}
+
+	cmd := exec.Command(bin, f.kubectlArgs(args...)...)
+	if stdin != "" {
+		cmd.Stdin = strings.NewReader(stdin)
+	}
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("kubectl %s: %v\n%s", strings.Join(args, " "), err, stderr.String())
+	}
+	return strings.TrimSpace(stdout.String())
+}
+
+// deployment probes readiness on fixtureMetricsPort regardless of servePort, so a
+// workload serving elsewhere is both unready and genuinely unreachable. The name
+// controls sort order among the service's pods.
+func (f kubeFixture) deployment(t *testing.T, name string, servePort int) {
+	t.Helper()
+
+	// CoreDNS needs a server block; the DNS port is unprivileged and unused.
+	f.kubectlStdin(t, fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+data:
+  Corefile: |
+    .:5300 {
+        errors
+        prometheus :%[3]d
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tunnel-e2e
+      deployment: %[1]s
+  template:
+    metadata:
+      labels:
+        app: tunnel-e2e
+        deployment: %[1]s
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+        - name: metrics
+          image: %[4]s
+          args: ["-conf", "/etc/coredns/Corefile"]
+          ports:
+            - name: metrics
+              containerPort: %[3]d
+          volumeMounts:
+            - name: corefile
+              mountPath: /etc/coredns
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: %[5]d
+            periodSeconds: 2
+            failureThreshold: 1
+      volumes:
+        - name: corefile
+          configMap:
+            name: %[1]s
+`, name, f.namespace, servePort, f.corednsImage(t), fixtureMetricsPort), "apply", "-f", "-")
+}
+
+func (f kubeFixture) corednsImage(t *testing.T) string {
+	t.Helper()
+	image := f.inNamespace("kube-system").kubectl(t, "get", "deployment", "coredns", "-o",
+		"jsonpath={.spec.template.spec.containers[0].image}")
+	if image == "" {
+		t.Skip("cluster has no coredns deployment to source a workload image from")
+	}
+	return image
+}
+
+// exposeService publishes a service port that differs from the container port.
+// targetPort may be numeric or the container port's name.
+func (f kubeFixture) exposeService(t *testing.T, targetPort string) {
+	t.Helper()
+	f.kubectlStdin(t, fmt.Sprintf(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  selector:
+    app: tunnel-e2e
+  ports:
+    - name: http
+      port: %[3]d
+      targetPort: %[4]s
+`, f.service, f.namespace, fixtureServicePort, targetPort), "apply", "-f", "-")
+}
+
+func (f kubeFixture) waitForRollout(t *testing.T, deployment string) {
+	t.Helper()
+	f.kubectl(t, "rollout", "status", "deployment/"+deployment, "--timeout=180s")
+}
+
+// waitForRunningPod deliberately does not require readiness, which is how the
+// broken workload is awaited. kubectl wait cannot do this: it fails outright
+// while no pod matches yet.
+func (f kubeFixture) waitForRunningPod(t *testing.T, deployment string) {
+	t.Helper()
+	deadline := time.Now().Add(180 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(f.podField(t, deployment, "status.phase"), "Running") {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("no running pod for deployment %s", deployment)
+}
+
+func (f kubeFixture) podNames(t *testing.T, deployment string) []string {
+	t.Helper()
+	return strings.Fields(f.podField(t, deployment, "metadata.name"))
+}
+
+// podsReady lets a test confirm a workload is unready rather than assume it.
+func (f kubeFixture) podsReady(t *testing.T, deployment string) string {
+	t.Helper()
+	return f.kubectl(t, "get", "pods", "-l", "deployment="+deployment, "-o",
+		`jsonpath={range .items[*]}{.status.conditions[?(@.type=="Ready")].status} {end}`)
+}
+
+func (f kubeFixture) podField(t *testing.T, deployment, field string) string {
+	t.Helper()
+	return f.kubectl(t, "get", "pods", "-l", "deployment="+deployment, "-o",
+		fmt.Sprintf("jsonpath={.items[*].%s}", field))
+}
+
+// tunnelConfig appends the given resource blocks to the data source. A zero
+// localPort lets the provider choose one.
+func tunnelConfig(f kubeFixture, targetPort, localPort int, blocks ...string) string {
+	localPortLine := ""
+	if localPort != 0 {
+		localPortLine = fmt.Sprintf("\n  local_port   = %d", localPort)
+	}
+	contextLine := ""
+	if f.kubeContext != "" {
+		contextLine = fmt.Sprintf("\n    config_context = %q", f.kubeContext)
+	}
+
+	return fmt.Sprintf(`
+terraform {
+  required_providers {
+    tunnel = {
+      source = "dfns/tunnel"
+    }
+  }
+}
+
+data "tunnel_kubernetes" "t" {
+  namespace    = %[1]q
+  service_name = %[2]q
+  target_port  = %[3]d%[4]s
+  kubernetes = {
+    config_path = %[5]q%[6]s
+  }
+}
+
+output "local_port" {
+  value = data.tunnel_kubernetes.t.local_port
+}
+`, f.namespace, f.service, targetPort, localPortLine,
+		filepath.ToSlash(f.kubeconfig), contextLine) + strings.Join(blocks, "")
+}
+
+func probe(name, output string) string {
+	command := fmt.Sprintf(
+		"curl -fsS --retry 15 --retry-delay 2 --retry-all-errors -o %s "+
+			"http://${data.tunnel_kubernetes.t.local_host}:${data.tunnel_kubernetes.t.local_port}/metrics",
+		output,
+	)
+	return fmt.Sprintf(`
+resource "terraform_data" %[1]q {
+  input = data.tunnel_kubernetes.t.local_port
+  provisioner "local-exec" {
+    command = %[2]q
+  }
+}
+`, name, command)
+}
+
+// assertMetrics distinguishes a real response from an empty or error one.
+func assertMetrics(t *testing.T, moduleDir, name string) {
+	t.Helper()
+	got, err := os.ReadFile(filepath.Join(moduleDir, name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	if !strings.Contains(string(got), "# HELP") {
+		t.Fatalf("%s is missing Prometheus markers; got %d bytes:\n%.300s", name, len(got), got)
+	}
+}
+
+func localPortOutput(t *testing.T, moduleDir string) int {
+	t.Helper()
+	port, err := strconv.Atoi(terraformOutput(t, moduleDir, "local_port"))
+	if err != nil {
+		t.Fatalf("parsing local_port output: %v", err)
+	}
+	return port
+}
+
+// TestKubernetesTunnelE2E forwards to a service the tests did not create, which
+// is the only coverage of a multi-port service managed by the cluster itself.
+func TestKubernetesTunnelE2E(t *testing.T) {
+	fixture := existingServiceFixture(t, "kube-system", "kube-dns")
+
+	for _, tt := range []struct {
+		name string
+		// requestedPort == 0 lets the provider pick a free port (the common case);
+		// otherwise it must bind exactly this one.
+		requestedPort func(t *testing.T) int
+	}{
+		{name: "auto_port", requestedPort: func(*testing.T) int { return 0 }},
+		{name: "explicit_port", requestedPort: func(t *testing.T) int {
+			port, err := libs.GetFreePort()
+			if err != nil {
+				t.Fatalf("allocating free port: %v", err)
+			}
+			return port
+		}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			requested := tt.requestedPort(t)
+			moduleDir := t.TempDir()
+			terraformApply(t, moduleDir, tunnelConfig(fixture, 9153, requested,
+				probe("probe", "resp.txt")))
+
+			assertMetrics(t, moduleDir, "resp.txt")
+
+			localPort := localPortOutput(t, moduleDir)
+			if requested != 0 && localPort != requested {
+				t.Fatalf("provider bound local_port %d, want the requested %d", localPort, requested)
+			}
+			// terraform has exited, so the forked tunnel must self-terminate and free
+			// its local port (the WatchProcess half of the cross-OS process handling).
+			assertTunnelTerminated(t, "localhost", localPort)
+		})
+	}
+}
+
+// TestKubernetesServicePortResolutionE2E covers the common 80 -> 8080 shape.
+// Forwarding the service port straight to the pod would reach a closed port.
+func TestKubernetesServicePortResolutionE2E(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		targetPort string
+	}{
+		{name: "numeric_target_port", targetPort: strconv.Itoa(fixtureMetricsPort)},
+		{name: "named_target_port", targetPort: "metrics"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			fixture := freshNamespaceFixture(t, "tunnel-e2e-ports-"+strings.ReplaceAll(tt.name, "_", "-"))
+			fixture.deployment(t, "serving", fixtureMetricsPort)
+			fixture.exposeService(t, tt.targetPort)
+			fixture.waitForRollout(t, "serving")
+
+			moduleDir := t.TempDir()
+			terraformApply(t, moduleDir, tunnelConfig(fixture, fixtureServicePort, 0,
+				probe("probe", "resp.txt")))
+
+			assertMetrics(t, moduleDir, "resp.txt")
+		})
+	}
+}
+
+// TestKubernetesSkipsUnreadyPodE2E puts a pod that sorts first but serves nothing
+// behind the service, which is what selecting the first pod used to reach.
+func TestKubernetesSkipsUnreadyPodE2E(t *testing.T) {
+	fixture := freshNamespaceFixture(t, "tunnel-e2e-unready")
+	// "aaa-" sorts ahead of "zzz-", so a first-pod selection lands on the broken
+	// workload.
+	fixture.deployment(t, "aaa-broken", fixtureWrongPort)
+	fixture.deployment(t, "zzz-serving", fixtureMetricsPort)
+	fixture.exposeService(t, strconv.Itoa(fixtureMetricsPort))
+	fixture.waitForRollout(t, "zzz-serving")
+	fixture.waitForRunningPod(t, "aaa-broken")
+
+	moduleDir := t.TempDir()
+	terraformApply(t, moduleDir, tunnelConfig(fixture, fixtureServicePort, 0,
+		probe("probe", "resp.txt")))
+
+	assertMetrics(t, moduleDir, "resp.txt")
+
+	// Guard the fixture itself: the broken pod has to exist and be unready, or the
+	// test would pass without exercising readiness filtering at all.
+	broken := fixture.podNames(t, "aaa-broken")
+	if len(broken) == 0 {
+		t.Fatal("fixture produced no pod for the broken workload")
+	}
+	if ready := fixture.podsReady(t, "aaa-broken"); !strings.Contains(ready, "False") {
+		t.Fatalf("broken workload pod readiness = %q, want False", ready)
+	}
 }


### PR DESCRIPTION
The `tunnel_kubernetes` tunnel forwarded `target_port` straight to the first pod the API returned, so it missed the pod port on any service whose `targetPort` differs from its `port`, and it could land on a pod that was unready or terminating.

