### PR TITLE
fix(ssm): terminate the session when the fork fails

### DIFF
--- a/internal/ssm/session.go
+++ b/internal/ssm/session.go
@@ -2,6 +2,7 @@ package ssm
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -12,6 +13,8 @@ import (
 
 // Default SSM document for port forwarding.
 const DefaultSSMDocument = "AWS-StartPortForwardingSessionToRemoteHost"
+
+const sessionCleanupTimeout = 10 * time.Second
 
 type TunnelConfig struct {
 	LocalPort   string
@@ -101,10 +104,7 @@ func CreateSessionInput(cfg TunnelConfig) ssm.StartSessionInput {
 	}
 }
 
-func StartTunnelSession(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) (SessionParams, error) {
-	// Create SSM client
-	ssmClient := ssm.NewFromConfig(awsCfg)
-
+func startTunnelSession(ctx context.Context, ssmClient *ssm.Client, cfg TunnelConfig) (SessionParams, error) {
 	// Make a request to start a session
 	sessionInput := CreateSessionInput(cfg)
 	sessionResponse, err := ssmClient.StartSession(ctx, &sessionInput)
@@ -117,4 +117,18 @@ func StartTunnelSession(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig
 		TokenValue: *sessionResponse.TokenValue,
 		StreamUrl:  *sessionResponse.StreamUrl,
 	}, nil
+}
+
+// terminateTunnelSession closes a session no plugin ever took over, which SSM
+// would otherwise hold until its idle timeout. Cancellation is stripped from
+// ctx because a done ctx is one way to reach this teardown, so the call gets a
+// deadline of its own instead.
+func terminateTunnelSession(ctx context.Context, ssmClient *ssm.Client, session SessionParams) error {
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionCleanupTimeout)
+	defer cancel()
+
+	_, err := ssmClient.TerminateSession(ctx, &ssm.TerminateSessionInput{
+		SessionId: aws.String(session.SessionId),
+	})
+	return err
 }

--- a/internal/ssm/tunnel.go
+++ b/internal/ssm/tunnel.go
@@ -35,7 +35,8 @@ func ForkRemoteTunnel(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) 
 	// resolution stays in the provider process, as the AWS CLI does before
 	// handing the response to the plugin, last checked at
 	// https://github.com/aws/aws-cli/blob/5ad8dc60682d72edf21be96f0a591402f91ee45e/awscli/customizations/sessionmanager.py
-	sessionParams, err := StartTunnelSession(ctx, awsCfg, cfg)
+	ssmClient := ssm.NewFromConfig(awsCfg)
+	sessionParams, err := startTunnelSession(ctx, ssmClient, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +48,13 @@ func ForkRemoteTunnel(ctx context.Context, awsCfg aws.Config, cfg TunnelConfig) 
 	}
 	logName := fmt.Sprintf("ssm-tunnel-%s-%s.log", cfg.SSMInstance, logPort)
 
-	return libs.ForkTunnel(ctx, TunnelType, logName, cfg)
+	cmd, err := libs.ForkTunnel(ctx, TunnelType, logName, cfg)
+	if err != nil {
+		if terr := terminateTunnelSession(ctx, ssmClient, sessionParams); terr != nil {
+			log.Printf("failed to terminate SSM session %s: %v", sessionParams.SessionId, terr)
+		}
+	}
+	return cmd, err
 }
 
 func StartRemoteTunnel(ctx context.Context, cfgJson string, parentPid int) (err error) {


### PR DESCRIPTION
The SSM session is started in the provider process before the tunnel child is forked, so it outlives a fork that never reaches the readiness handshake. `libs.ForkTunnel` reaps the child in that case, but nothing closes the session, and AWS holds it until its own idle timeout expires.